### PR TITLE
Add rss to install identifier list

### DIFF
--- a/manual/list_shiori_event.html
+++ b/manual/list_shiori_event.html
@@ -2341,6 +2341,7 @@
 					<li>balloon</li>
 					<li>plugin</li>
 					<li>headline</li>
+					<li>rss</li>
 					<li>supplement</li>
 				</ul>
 				<p>以下はOnInstallComplete / OnNarCreatedのみ</p>


### PR DESCRIPTION
RSS seems to be missing from the list. I tested with my ghost and confirmed this is the identifier used when installing an RSS feed, and is separate from the headline identifier.