### PR TITLE
Add target ghost selector

### DIFF
--- a/manual/list_sakura_script.html
+++ b/manual/list_sakura_script.html
@@ -133,6 +133,21 @@
 	</nav>
 	<section class="navigation-bar">
 		<h1>さくらスクリプト</h1>
+		<section class="navigation-category" id="TargetGhost" style="display: none;">
+			<h1>Target Ghost</h1>
+			<!-- 一个列表用于?示和??ghost -->
+			<div id="ghost_select">
+				<p>Please select a target ghost for example scripts:</p>
+				<select id="ghost_list_content" onchange="reload_button()"></select>
+				<!-- reloadボタン -->
+				<button id="ghost_reload_button" onclick="reload_button()">Reload</button>
+			</div>
+			<div id="supported_text_event_Has_Event_reminder">
+				<p>Some tags are considered dangerous, and will not run unless your ghost supports the following event:</p>
+				<a href="./list_shiori_event_ex.html#OnUkadocScriptExample">OnUkadocScriptExample</a>
+				<p>When using this event, please take care to escape dangerous tags yourself.</p>
+			</div>
+		</section>
 		<section class="navigation-category">
 			<h1>さくらスクリプトの仕様</h1>
 			<ul>

--- a/manual/list_sakura_script.html
+++ b/manual/list_sakura_script.html
@@ -133,7 +133,7 @@
 	</nav>
 	<section class="navigation-bar">
 		<h1>さくらスクリプト</h1>
-		<section class="navigation-category" id="TargetGhost" style="display: none;">
+		<section class="navigation-category" id="TargetGhost" style="display: block;">
 			<h1>Target Ghost</h1>
 			<!-- 一个列表用于?示和??ghost -->
 			<div id="ghost_select">

--- a/manual/list_sakura_script.html
+++ b/manual/list_sakura_script.html
@@ -142,7 +142,7 @@
 				<!-- reloadボタン -->
 				<button id="ghost_reload_button" onclick="reload_button()">Reload</button>
 			</div>
-			<div id="supported_text_event_Has_Event_reminder">
+			<div>
 				<p>Some tags are considered dangerous, and will not run unless your ghost supports the following event:</p>
 				<a href="./list_shiori_event_ex.html#OnUkadocScriptExample">OnUkadocScriptExample</a>
 				<p>When using this event, please take care to escape dangerous tags yourself.</p>

--- a/manual/list_sakura_script.html
+++ b/manual/list_sakura_script.html
@@ -137,15 +137,15 @@
 			<h1>Target Ghost</h1>
 			<!-- 一个列表用于?示和??ghost -->
 			<div id="ghost_select">
-				<p>スクリプトの例については、対象のゴーストを選択してください：</p>
+				<p>記述例を実行する対象のゴーストを選択してください：</p>
 				<select id="ghost_list_content" onchange="reload_button()"></select>
 				<!-- reloadボタン -->
 				<button id="ghost_reload_button" onclick="reload_button()">リロード</button>
 			</div>
 			<div>
-				<p>いくつかのタグは危険とみなされ、あなたのゴーストが以下のイベントをサポートしていない限り実行されません：</p>
+				<p>いくつかのタグは危険であるため、対象ゴーストが以下のイベントをサポートしていない限り実行されません：</p>
 				<a href="./list_shiori_event_ex.html#OnUkadocScriptExample">OnUkadocScriptExample</a>
-				<p>本イベントをご利用の際は、危険なタグの取り扱いには十分ご注意ください。</p>
+				<p>イベントを実行する際は、危険なタグをエスケープするよう十分ご注意ください。</p>
 			</div>
 		</section>
 		<section class="navigation-category">

--- a/manual/list_sakura_script.html
+++ b/manual/list_sakura_script.html
@@ -137,15 +137,15 @@
 			<h1>Target Ghost</h1>
 			<!-- 一个列表用于?示和??ghost -->
 			<div id="ghost_select">
-				<p>Please select a target ghost for example scripts:</p>
+				<p>スクリプトの例については、対象のゴーストを選択してください：</p>
 				<select id="ghost_list_content" onchange="reload_button()"></select>
 				<!-- reloadボタン -->
-				<button id="ghost_reload_button" onclick="reload_button()">Reload</button>
+				<button id="ghost_reload_button" onclick="reload_button()">リロード</button>
 			</div>
 			<div>
-				<p>Some tags are considered dangerous, and will not run unless your ghost supports the following event:</p>
+				<p>いくつかのタグは危険とみなされ、あなたのゴーストが以下のイベントをサポートしていない限り実行されません：</p>
 				<a href="./list_shiori_event_ex.html#OnUkadocScriptExample">OnUkadocScriptExample</a>
-				<p>When using this event, please take care to escape dangerous tags yourself.</p>
+				<p>本イベントをご利用の際は、危険なタグの取り扱いには十分ご注意ください。</p>
 			</div>
 		</section>
 		<section class="navigation-category">

--- a/manual/sakura_player.js
+++ b/manual/sakura_player.js
@@ -12,7 +12,6 @@ document.addEventListener('DOMContentLoaded', () =>
 	.then(m => (jsstp = m.jsstp).if_available(init_content).then(reload_button)).catch(e => e)
 );
 async function init_content() {
-	document.getElementById("TargetGhost").style.display = "block";
 	// 获取所有的SakuraScript代码
 	const sakuraScriptCodes = document.querySelectorAll("code[type='SakuraScript']");
 	// 为其增加一个按钮，点击后执行SakuraScript

--- a/manual/sakura_player.js
+++ b/manual/sakura_player.js
@@ -7,7 +7,7 @@ var jsstp;
 //页面加载完成后，检查ghost可用性
 document.addEventListener('DOMContentLoaded', () =>
 	import("https://cdn.jsdelivr.net/gh/ukatech/jsstp-lib@v3.0.0.1/dist/jsstp.mjs")
-	.then(m => (jsstp = m.jsstp).if_available(init_content).then(reload_button)).catch(e => e)
+		.then(m => (jsstp = m.jsstp).if_available(init_content).then(reload_button)).catch(e => e)
 );
 async function init_content() {
 	// 获取所有的SakuraScript代码
@@ -17,7 +17,7 @@ async function init_content() {
 		const button = createExecutionButton(code.textContent);
 		const parent = code.parentElement.parentElement;
 		// 若父元素的子元素除了h1外只有一个元素，那么将按钮插入到h1后面
-		if (parent.children.length === 2) {
+		if (parent.children.length == 2) {
 			parent.insertBefore(button, parent.children[1]);
 			//取消h1的换行
 			parent.children[0].style.display = "inline";
@@ -58,10 +58,8 @@ function reload_button() {
 		//根据备份的选项重新选中（如果还在列表中的话）
 		if (fmo[selected])
 			list.value = selected;
-		else {
+		else
 			selected = list.value = list.options[0].value;
-			console.log(list.options[0].innerText);
-		}
 		jsstp = jsstp.by_fmo_info(fmo[selected]);
 	}).catch(e => {
 		console.error(e);

--- a/manual/sakura_player.js
+++ b/manual/sakura_player.js
@@ -4,8 +4,6 @@
 /** @type {typeof import("jsstp").jsstp} */
 var jsstp;
 
-var selectedGhost;
-
 //页面加载完成后，检查ghost可用性
 document.addEventListener('DOMContentLoaded', () =>
 	import("https://cdn.jsdelivr.net/gh/ukatech/jsstp-lib@v3.0.0.1/dist/jsstp.mjs")
@@ -40,8 +38,7 @@ function createExecutionButton(script) {
 			Event: "OnUkadocScriptExample",
 			Reference0: script,
 			Script: script,
-			Option: "notranslate",
-			ReceiverGhostName: selectedGhost
+			Option: "notranslate"
 		});
 	});
 	return button;
@@ -59,15 +56,13 @@ function reload_button() {
 			throw new Error("get_fmo_infos failed");
 		fmo.forEach((info, uuid) => list.options.add(new Option(info.name, uuid)));
 		//根据备份的选项重新选中（如果还在列表中的话）
-		if (fmo[selected]) {
+		if (fmo[selected])
 			list.value = selected;
-			selectedGhost = fmo[selected].name;
-		}
 		else {
 			selected = list.value = list.options[0].value;
 			console.log(list.options[0].innerText);
-			selectedGhost = list.options[0].innerText;
 		}
+		jsstp = jsstp.by_fmo_info(fmo[selected]);
 	}).catch(e => {
 		console.error(e);
 	});


### PR DESCRIPTION
Add a target ghost selector on the Sakura Script list, to choose what ghost to send example scripts to when multiple ghosts are running.
Also, include a bit of info about the corresponding event, and the fact that some tags will not run without it.

My javascript is clumsy and I don't understand a lot of what's happening in these functions, so please review it!

2 other requests, as well:

1. The text needs to be translated to Japanese.
2. Can someone please list OnUkadocScriptExample on the External SHIORI Event list?

Thank you! 🙇 