### PR TITLE
Group by category

### DIFF
--- a/manual/list_shiori_event_ex.html
+++ b/manual/list_shiori_event_ex.html
@@ -155,6 +155,81 @@
 			</div>
 		</section>
 		<section class="navigation-category">
+			<h1>ゴースト間汎用イベント</h1>
+			<ul>
+				<li><a href="#OnRequestValues">OnRequestValues</a></li>
+				<li><a href="#OnGetValues">OnGetValues</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>ゴースト「ぬるぽ いんたーはい」</h1>
+			<ul>
+				<li><a href="#OnTalkRequest">OnTalkRequest</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>ゴースト「The Hand」</h1>
+			<ul>
+				<li><a href="#OnHandActivate">OnHandActivate</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>ゴースト「ごーすとじてん」「きゅーぴっど」</h1>
+			<ul>
+				<li><a href="#OnJitenBattle">OnJitenBattle</a></li>
+				<li><a href="#OnJitenTagBattle">OnJitenTagBattle</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>ゴースト「マギルトリエ」</h1>
+			<ul>
+				<li><a href="#OnMglBattle">OnMglBattle</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>ゴースト「カレー家族／沙紀と右近」</h1>
+			<ul>
+				<li><a href="#Send60stair_Call">Send60stair_Call</a></li>
+				<li><a href="#Send60stair_Start">Send60stair_Start</a></li>
+				<li><a href="#Send60stair_YourTurnStart">Send60stair_YourTurnStart</a></li>
+				<li><a href="#Send60stair_Marking">Send60stair_Marking</a></li>
+				<li><a href="#Send60stair_DiceRoll">Send60stair_DiceRoll</a></li>
+				<li><a href="#Send60stair_Dobon">Send60stair_Dobon</a></li>
+				<li><a href="#Send60stair_YourTurnEnd">Send60stair_YourTurnEnd</a></li>
+				<li><a href="#Send60stair_Goal">Send60stair_Goal</a></li>
+				<li><a href="#Send60stair_GameEnd">Send60stair_GameEnd</a></li>
+				<li><a href="#Send60stair_GetStatus">Send60stair_GetStatus</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>ゴースト「奏でる日常の音色」</h1>
+			<ul>
+				<li><a href="#OnKanadeTeaPartyInfomationRequest">OnKanadeTeaPartyInfomationRequest</a></li>
+				<li><a href="#可変名の返信イベント">可変名の返信イベント</a></li>
+				<li><a href="#OnKanadeTeaParty">OnKanadeTeaParty</a></li>
+				<li><a href="#OnKanadeTeaPartyEnd">OnKanadeTeaPartyEnd</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>ゴースト「卓上誘技」</h1>
+			<ul>
+				<li><a href="#OnPoker">OnPoker</a></li>
+				<li><a href="#OnPokerNotify">OnPokerNotify</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>ゴースト「フォーリナー」サプリメント「march of phantasma」</h1>
+			<ul>
+				<li><a href="#OnMopClear">OnMopClear</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>ゴースト「Needle」</h1>
+			<ul>
+				<li><a href="#OnNeedlePoke">OnNeedlePoke</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
 			<h1>プラグイン「バーチャルビールかけ（BeerShower）」</h1>
 			<ul>
 				<li><a href="#OnBeerShower">OnBeerShower</a></li>
@@ -196,21 +271,20 @@
 			</ul>
 		</section>
 		<section class="navigation-category">
-			<h1>SAORI「httpc.dll」</h1>
+			<h1>プラグイン「Weather Station」</h1>
 			<ul>
-				<li><a href="#OnHttpcNotify">OnHttpcNotify</a></li>
+				<li><a href="#OnWeatherStation.Weather">OnWeatherStation.Weather</a></li>
+				<li><a href="#OnWeatherStation.Astro">OnWeatherStation.Astro</a></li>
+				<li><a href="#OnWeatherStation.Alerts">OnWeatherStation.Alerts</a></li>
+				<li><a href="#OnWeatherStation.Forecast.Day">OnWeatherStation.Forecast.Day</a></li>
+				<li><a href="#OnWeatherStation.Forecast.Hourly">OnWeatherStation.Forecast.Hourly</a></li>
+				<li><a href="#OnWeatherStation.Error">OnWeatherStation.Error</a></li>
 			</ul>
 		</section>
 		<section class="navigation-category">
-			<h1>外部アプリ汎用イベント</h1>
+			<h1>SAORI「httpc.dll」</h1>
 			<ul>
-				<li><a href="#OnApplicationBoot">OnApplicationBoot</a></li>
-				<li><a href="#OnApplicationClose">OnApplicationClose</a></li>
-				<li><a href="#OnApplicationExist">OnApplicationExist</a></li>
-				<li><a href="#OnApplicationVersion">OnApplicationVersion</a></li>
-				<li><a href="#OnApplicationOperationFinish">OnApplicationOperationFinish</a></li>
-				<li><a href="#OnApplicationFileOpen">OnApplicationFileOpen</a></li>
-				<li><a href="#OnWebsiteUpdateNotify">OnWebsiteUpdateNotify</a></li>
+				<li><a href="#OnHttpcNotify">OnHttpcNotify</a></li>
 			</ul>
 		</section>
 		<section class="navigation-category">
@@ -349,75 +423,6 @@
 			</ul>
 		</section>
 		<section class="navigation-category">
-			<h1>ゴースト間汎用イベント</h1>
-			<ul>
-				<li><a href="#OnRequestValues">OnRequestValues</a></li>
-				<li><a href="#OnGetValues">OnGetValues</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
-			<h1>ゴースト「ぬるぽ いんたーはい」</h1>
-			<ul>
-				<li><a href="#OnTalkRequest">OnTalkRequest</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
-			<h1>ゴースト「The Hand」</h1>
-			<ul>
-				<li><a href="#OnHandActivate">OnHandActivate</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
-			<h1>ゴースト「ごーすとじてん」「きゅーぴっど」</h1>
-			<ul>
-				<li><a href="#OnJitenBattle">OnJitenBattle</a></li>
-				<li><a href="#OnJitenTagBattle">OnJitenTagBattle</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
-			<h1>ゴースト「マギルトリエ」</h1>
-			<ul>
-				<li><a href="#OnMglBattle">OnMglBattle</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
-			<h1>ゴースト「カレー家族／沙紀と右近」</h1>
-			<ul>
-				<li><a href="#Send60stair_Call">Send60stair_Call</a></li>
-				<li><a href="#Send60stair_Start">Send60stair_Start</a></li>
-				<li><a href="#Send60stair_YourTurnStart">Send60stair_YourTurnStart</a></li>
-				<li><a href="#Send60stair_Marking">Send60stair_Marking</a></li>
-				<li><a href="#Send60stair_DiceRoll">Send60stair_DiceRoll</a></li>
-				<li><a href="#Send60stair_Dobon">Send60stair_Dobon</a></li>
-				<li><a href="#Send60stair_YourTurnEnd">Send60stair_YourTurnEnd</a></li>
-				<li><a href="#Send60stair_Goal">Send60stair_Goal</a></li>
-				<li><a href="#Send60stair_GameEnd">Send60stair_GameEnd</a></li>
-				<li><a href="#Send60stair_GetStatus">Send60stair_GetStatus</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
-			<h1>ゴースト「奏でる日常の音色」</h1>
-			<ul>
-				<li><a href="#OnKanadeTeaPartyInfomationRequest">OnKanadeTeaPartyInfomationRequest</a></li>
-				<li><a href="#可変名の返信イベント">可変名の返信イベント</a></li>
-				<li><a href="#OnKanadeTeaParty">OnKanadeTeaParty</a></li>
-				<li><a href="#OnKanadeTeaPartyEnd">OnKanadeTeaPartyEnd</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
-			<h1>ゴースト「卓上誘技」</h1>
-			<ul>
-				<li><a href="#OnPoker">OnPoker</a></li>
-				<li><a href="#OnPokerNotify">OnPokerNotify</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
-			<h1>ゴースト「フォーリナー」サプリメント「march of phantasma」</h1>
-			<ul>
-				<li><a href="#OnMopClear">OnMopClear</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
 			<h1>ゴースト開発用の対話型exe「ゴースト・ターミナル」</h1>
 			<ul>
 				<li><a href="#ShioriEcho.Begin">ShioriEcho.Begin</a></li>
@@ -436,29 +441,6 @@
 			</ul>
 		</section>
 		<section class="navigation-category">
-			<h1>プラグイン「Weather Station」</h1>
-			<ul>
-				<li><a href="#OnWeatherStation.Weather">OnWeatherStation.Weather</a></li>
-				<li><a href="#OnWeatherStation.Astro">OnWeatherStation.Astro</a></li>
-				<li><a href="#OnWeatherStation.Alerts">OnWeatherStation.Alerts</a></li>
-				<li><a href="#OnWeatherStation.Forecast.Day">OnWeatherStation.Forecast.Day</a></li>
-				<li><a href="#OnWeatherStation.Forecast.Hourly">OnWeatherStation.Forecast.Hourly</a></li>
-				<li><a href="#OnWeatherStation.Error">OnWeatherStation.Error</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
-			<h1>ゴースト「Needle」</h1>
-			<ul>
-				<li><a href="#OnNeedlePoke">OnNeedlePoke</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
-			<h1>UKADOC</h1>
-			<ul>
-				<li><a href="#OnUkadocScriptExample">OnUkadocScriptExample</a></li>
-			</ul>
-		</section>
-		<section class="navigation-category">
 			<h1>アプリ「Elin」</h1>
 			<ul>
 				<li><a href="#OnElinAllyCondition">OnElinAllyCondition</a></li>
@@ -470,6 +452,24 @@
 				<li><a href="#OnElinPCCondition">OnElinPCCondition</a></li>
 				<li><a href="#OnElinPCDead">OnElinPCDead</a></li>
 				<li><a href="#OnElinTarget">OnElinTarget</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>外部アプリ汎用イベント</h1>
+			<ul>
+				<li><a href="#OnApplicationBoot">OnApplicationBoot</a></li>
+				<li><a href="#OnApplicationClose">OnApplicationClose</a></li>
+				<li><a href="#OnApplicationExist">OnApplicationExist</a></li>
+				<li><a href="#OnApplicationVersion">OnApplicationVersion</a></li>
+				<li><a href="#OnApplicationOperationFinish">OnApplicationOperationFinish</a></li>
+				<li><a href="#OnApplicationFileOpen">OnApplicationFileOpen</a></li>
+				<li><a href="#OnWebsiteUpdateNotify">OnWebsiteUpdateNotify</a></li>
+			</ul>
+		</section>
+		<section class="navigation-category">
+			<h1>UKADOC</h1>
+			<ul>
+				<li><a href="#OnUkadocScriptExample">OnUkadocScriptExample</a></li>
 			</ul>
 		</section>
 	</section>
@@ -492,6 +492,557 @@
 				<li><a href="list_sakura_script.html#_!_raiseplugin,%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%AEID%E3%81%BE%E3%81%9F%E3%81%AF%E5%90%8D%E5%89%8D,%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E5%90%8D,r0,r1,r2..._">\![raiseplugin]</a></li>
 				<li><a href="list_sakura_script.html#_!_notifyplugin,%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%AEID%E3%81%BE%E3%81%9F%E3%81%AF%E5%90%8D%E5%89%8D,%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E5%90%8D,r0,r1,r2..._">\![notifyplugin]</a></li>
 			</ul>
+		</section>
+		<section class="category ghost">
+			<h1>ゴースト間汎用イベント</h1>
+			<dl id="OnRequestValues">
+				<dt class="entry">OnRequestValues</dt>
+				<dd class="entry">
+					<p>他ゴーストが任意に送信した際に発生。<br />このイベントが送られた時、\[raiseother]でOnGetValuesイベントを送信する必要がある。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>送信したゴースト名。</dd>
+						<dt>Reference1</dt>
+						<dd>要求する変数名(key)。Reference2以降も同様に要求する変数がある限り続く。</dd>
+					</dl>
+					<ul class="supported-baseware">
+						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+					</ul>
+				</dd>
+			</dl>
+			<dl id="OnGetValues">
+				<dt class="entry">OnGetValues</dt>
+				<dd class="entry">
+					<p>OnRequestValuesを受けた際に返すべきイベント。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>送信するゴースト名。</dd>
+						<dt>Reference1</dt>
+						<dd>key=value(keyはOnRequestValuesで受け取った変数名、valueはその値)。Reference2以降も同様に要求された変数がある限り続く。存在しない変数は返さない。OnRequestValuesで送られた順序に依存しない。</dd>
+					</dl>
+					<ul class="supported-baseware">
+						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+					</ul>
+				</dd>
+			</dl>
+			<div class="caption">
+				<h1>要求されるプロパティ名一覧</h1>
+				<ul>
+					<li>キャラクター名</li>
+					<li>世代</li>
+					<li>年齢層</li>
+					<li>性別</li>
+					<li>種族</li>
+					<li>種族タイプ</li>
+					<li>行動タイプ</li>
+					<li>プロフィール</li>
+					<li>カード画像パス</li>
+					<li>LIFE</li>
+					<li>STR</li>
+					<li>DEX</li>
+					<li>AGL</li>
+					<li>MIN</li>
+					<li>INT</li>
+					<li>SEN</li>
+					<li>NOB</li>
+				</ul>
+			</div>
+		</section>
+		<section class="category ghost">
+			<h1>ゴースト「ぬるぽ いんたーはい」</h1>
+			<ul class="caption link">
+				<li>公開元：閉鎖</li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="OnTalkRequest">
+				<dt class="entry">OnTalkRequest</dt>
+				<dd class="entry">
+					<p>ぬるぽ　いんたーはいからトークを求められた際に発生。</p>
+				</dd>
+			</dl>
+		</section>
+		<section class="category ghost">
+			<h1>ゴースト「The Hand」</h1>
+			<ul class="caption link">
+				<li>公開元：<a href="http://ukiya.sakura.ne.jp/">http://ukiya.sakura.ne.jp/</a></li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="OnHandActivate">
+				<dt class="entry">OnHandActivate</dt>
+				<dd class="entry">
+					<p>The Handが他ゴーストを触りに行くまたは触り終わった際に発生。<br />触っている間、Sender:The Handでゴーストに(OnMouseMove|OnMouseDoubleClick|OnMouseWheel)イベントを送る。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>通常触り開始：NormalStart<br />通常触り終了：NormalEnd<br />必殺技開始：SuperStart<br />必殺技途中：SuperContinue<br />必殺技終了：SuperEnd<br />必殺技途中でホーミング発動：SuperHoming</dd>
+						<dt>Reference1</dt>
+						<dd>当たり判定名。<br />停止された場合はescaped。<br />必殺技の場合は1～4。</dd>
+						<dt>Reference2</dt>
+						<dd>相手に起きるイベント。<br />通常時：(OnMouseMove|OnMouseDoubleClick|OnMouseWheel)<br />必殺技中：触った回数<br />必殺技終了時：(MAX触り回数|escaped|nocollision|attacked|deleted)</dd>
+						<dt>Reference3</dt>
+						<dd>触りに行く際のスクリプト。<br />必殺技中は当たり判定名。</dd>
+						<dt>Reference4</dt>
+						<dd>シェル番号。</dd>
+					</dl>
+				</dd>
+			</dl>
+		</section>
+		<section class="category ghost">
+			<h1>ゴースト「ごーすとじてん」</h1>
+			<ul class="caption link">
+				<li>公開元：<a href="https://github.com/nikolat/ghostbook">https://github.com/nikolat/ghostbook</a></li>
+				<li>関連：<a href="http://spoon.if.land.to/wiki/index.php?%A4%B4%A1%BC%A4%B9%A4%C8%A4%B8%A4%C6%A4%F3">http://spoon.if.land.to/wiki/index.php?%A4%B4%A1%BC%A4%B9%A4%C8%A4%B8%A4%C6%A4%F3</a></li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="OnJitenBattle">
+				<dt class="entry">OnJitenBattle</dt>
+				<dd class="entry">
+					<p>ゴーストが行う模擬戦の毎ターン発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>送信したゴーストの\0名。</dd>
+						<dt>Reference1</dt>
+						<dd>攻撃側キャラクタ名。</dd>
+						<dt>Reference2</dt>
+						<dd>防御側キャラクタ名。</dd>
+						<dt>Reference3</dt>
+						<dd>戦闘結果。<br />開始時：模擬戦闘開始<br />行動時：(物理攻撃成功|物理攻撃失敗|物理攻撃回避|物理攻撃ミス|精神攻撃成功|精神攻撃失敗|精神攻撃回避|精神攻撃ミス)</dd>
+						<dt>Reference4</dt>
+						<dd>ダメージ。</dd>
+						<dt>Reference5</dt>
+						<dd>攻撃側キャラクタLIFE。</dd>
+						<dt>Reference6</dt>
+						<dd>防御側キャラクタLIFE。</dd>
+						<dt>Reference7</dt>
+						<dd>Normal</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="OnJitenTagBattle">
+				<dt class="entry">OnJitenTagBattle</dt>
+				<dd class="entry">
+					<p>ゴーストが行う模擬戦の毎ターン発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>送信したゴーストの\0名。</dd>
+						<dt>Reference1</dt>
+						<dd>攻撃側キャラクタ名。</dd>
+						<dt>Reference2</dt>
+						<dd>防御側キャラクタ名。</dd>
+						<dt>Reference3</dt>
+						<dd>戦闘結果。<br />開始時：模擬戦闘開始<br />行動時：(物理攻撃成功|物理攻撃失敗|物理攻撃回避|物理攻撃ミス|精神攻撃成功|精神攻撃失敗|精神攻撃回避|精神攻撃ミス)</dd>
+						<dt>Reference4</dt>
+						<dd>ダメージ。</dd>
+						<dt>Reference5</dt>
+						<dd>攻撃側キャラクタLIFE。</dd>
+						<dt>Reference6</dt>
+						<dd>防御側キャラクタLIFE。</dd>
+						<dt>Reference7</dt>
+						<dd>Tag</dd>
+					</dl>
+				</dd>
+			</dl>
+		</section>
+		<section class="category ghost">
+			<h1>ゴースト「マギルトリエ」</h1>
+			<ul class="caption link">
+				<li>公開元：閉鎖</li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="OnMglBattle">
+				<dt class="entry">OnMglBattle</dt>
+				<dd class="entry">
+					<p>マギルトリエが行うバーチャルバトルの結果ごとに発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>バージョン情報。</dd>
+						<dt>Reference2</dt>
+						<dd>送信元ゴースト。</dd>
+						<dt>Reference3</dt>
+						<dd>Mglイベント名。</dd>
+						<dt>Reference*</dt>
+						<dd>Mglイベントに対する内容。</dd>
+					</dl>
+				</dd>
+			</dl>
+		</section>
+		<section class="category ghost">
+			<h1>ゴースト「カレー家族／沙紀と右近」</h1>
+			<ul class="caption link">
+				<li>公開元：<a href="http://curryfamily.me.land.to/ghost_saki.html">http://curryfamily.me.land.to/ghost_saki.html</a></li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="Send60stair_Call">
+				<dt class="entry">Send60stair_Call</dt>
+				<dd class="entry">
+					<p>カレー家族／沙紀と右近が同時起動しているゴーストをゲームに誘う際に発生。</p>
+				</dd>
+			</dl>
+			<dl id="Send60stair_Start">
+				<dt class="entry">Send60stair_Start</dt>
+				<dd class="entry">
+					<p>カレー家族／沙紀と右近がゲームを開始する際に発生。</p>
+					<ul class="supported-baseware">
+						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+					</ul>
+				</dd>
+			</dl>
+			<dl id="Send60stair_YourTurnStart">
+				<dt class="entry">Send60stair_YourTurnStart</dt>
+				<dd class="entry">
+					<p>カレー家族／沙紀と右近が行うゲーム中に自ゴーストの順番が来た際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>現在位置。</dd>
+						<dt>Reference1</dt>
+						<dd>マーキング位置。</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="Send60stair_Marking">
+				<dt class="entry">Send60stair_Marking</dt>
+				<dd class="entry">
+					<p>カレー家族／沙紀と右近が行うゲーム中にマーキングした際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>マーキング位置。</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="Send60stair_DiceRoll">
+				<dt class="entry">Send60stair_DiceRoll</dt>
+				<dd class="entry">
+					<p>カレー家族／沙紀と右近が行うゲーム中にゴーストがサイコロを振り、ドボンでない際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>第一サイコロの出目。</dd>
+						<dt>Reference1</dt>
+						<dd>第二サイコロの出目。</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="Send60stair_Dobon">
+				<dt class="entry">Send60stair_Dobon</dt>
+				<dd class="entry">
+					<p>カレー家族／沙紀と右近が行うゲーム中に参加ゴーストのいずれかがドボンした際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>ドボンしたゴースト名。</dd>
+						<dt>Reference1</dt>
+						<dd>ドボンしたゴーストの現在位置。</dd>
+						<dt>Reference2</dt>
+						<dd>ドボンしたゴーストのマーキング位置。</dd>
+						<dt>Reference3</dt>
+						<dd>サイコロの出目。</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="Send60stair_YourTurnEnd">
+				<dt class="entry">Send60stair_YourTurnEnd</dt>
+				<dd class="entry">
+					<p>カレー家族／沙紀と右近が行うゲーム中に自ゴーストのターンが終了した際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>現在位置。</dd>
+						<dt>Reference1</dt>
+						<dd>マーキング位置。</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="Send60stair_Goal">
+				<dt class="entry">Send60stair_Goal</dt>
+				<dd class="entry">
+					<p>カレー家族／沙紀と右近が行うゲーム中にいずれかのゴーストがゴールした際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>優勝したゴースト名。</dd>
+						<dt>Reference1</dt>
+						<dd>順位。</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="Send60stair_GameEnd">
+				<dt class="entry">Send60stair_GameEnd</dt>
+				<dd class="entry">
+					<p>カレー家族／沙紀と右近が行うゲーム終了時、順位を表示した後に発生。</p>
+				</dd>
+			</dl>
+			<dl id="Send60stair_GetStatus">
+				<dt class="entry">Send60stair_GetStatus</dt>
+				<dd class="entry">
+					<p>\[raiseother]で沙紀に送信するべきイベント。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>送信するゴーストの\0名。</dd>
+						<dt>Reference1</dt>
+						<dd>大胆さ。(0～60)</dd>
+					</dl>
+				</dd>
+			</dl>
+		</section>
+		<section class="category ghost">
+			<h1>ゴースト「奏でる日常の音色」</h1>
+			<ul class="caption link">
+				<li>公開元：<a href="http://ukananachi.blog98.fc2.com/">http://ukananachi.blog98.fc2.com/</a></li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="OnKanadeTeaPartyInfomationRequest">
+				<dt class="entry">OnKanadeTeaPartyInfomationRequest</dt>
+				<dd class="entry">
+					<p>お茶会開始前に、奏でる日常の音色から各ゴーストに通知されるイベント。<br />お茶会に参加するゴーストはこのイベントで直ちに、<br /><code>\![raiseother,かなで,<a href="#可変名の返信イベント">返信イベント名</a>,ゴーストの対応するお茶会バージョン番号,ゴーストの本体側名,<a href="#caption_kanade">※お茶会バージョンへの対応情報</a>]</code><br />のさくらスクリプトを実行する必要がある。<br />イベント内での、このスクリプトの実行以外のトークは非推奨。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>お茶会バージョン番号。</dd>
+						<dt>Reference1</dt>
+						<dd>返信イベントの送信先ゴースト本体側名（「かなで」に固定）。</dd>
+						<dt>Reference2</dt>
+						<dd>返信イベント名。</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="可変名の返信イベント">
+				<dt class="entry">可変名の返信イベント</dt>
+				<dd class="entry">
+					<p>OnKanadeTeaPartyInfomationRequestを受信したゴーストが、<em>奏でる日常の音色に対して</em>raiseotherで<em>通知する</em>イベント。<br />イベント名はOnKanadeTeaPartyInfomationRequestのreference2で通知されている。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>ゴーストの対応するお茶会バージョン番号</dd>
+						<dt>Reference1</dt>
+						<dd>ゴーストの本体側名</dd>
+						<dt>Reference2</dt>
+						<dd><a href="#caption_kanade">※お茶会バージョンへの対応情報</a></dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="OnKanadeTeaParty">
+				<dt class="entry">OnKanadeTeaParty</dt>
+				<dd class="entry">
+					<p>お茶会本体イベント。お茶会開始時に通知される。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>Reference1以降の組み合わせが実装されたお茶会のバージョン。</dd>
+						<dt>Reference1</dt>
+						<dd>お飲み物。</dd>
+						<dt>Reference2</dt>
+						<dd>お菓子</dd>
+						<dt>Reference*</dt>
+						<dd>Reference3以降は拡張情報。</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="OnKanadeTeaPartyEnd">
+				<dt class="entry">OnKanadeTeaPartyEnd</dt>
+				<dd class="entry">
+					<p>お茶会終了イベント。奏でる日常の音色が、お茶会終了トークをした後に通知される。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>実行されたお茶会のバージョン。</dd>
+					</dl>
+				</dd>
+			</dl>
+			<div class="caption" id="caption_kanade">
+				<p>※お茶会バージョンへの対応情報</p>
+				<dl>
+					<dt>対応</dt>
+					<dd>
+						「奏でる日常の音色」のバージョンよりもゴーストのバージョンが高いまたは同じなため、この「奏でる日常の音色」が提供するお茶会イベントに完全に対応しています。
+					</dd>
+					<dt>非対応</dt>
+					<dd>
+						「奏でる日常の音色」のバージョンよりもゴーストのバージョンが低いため、ゴーストのバージョンよりも高いバージョンのお茶会イベントは処理することができません。
+					</dd>
+					<dt>自動対応</dt>
+					<dd>
+						「奏でる日常の音色」のバージョンよりもゴーストのバージョンが低いですが、ゴーストのバージョンよりも高いバージョンのお茶会イベントについて、単語を当てはめたりなどトークの内容を変化させて自動的に対応することができます。
+					</dd>
+					<dt>固定対応</dt>
+					<dd>
+						「奏でる日常の音色」が提供するお茶会の内容によって対応は変化しません。返答イベントのReference0はゴーストの制作者が確認しているお茶会バージョンです。この対応情報を返送したゴーストについては、お茶会の内容選択を考慮しません。
+					</dd>
+				</dl>
+			</div>
+		</section>
+		<section class="category ghost">
+			<h1>ゴースト「卓上誘技」</h1>
+			<ul class="caption link">
+				<li>公開元：<a href="https://tatakinov.github.io/">https://tatakinov.github.io/</a></li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="OnPoker">
+				<dt class="entry">OnPoker</dt>
+				<dd class="entry">
+					<p>応答が必要なイベント。応答方法はraiseotherかnotifyotherを使う。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>プロトコルバージョン(POKER/1.0)</dd>
+						<dt>Reference1</dt>
+						<dd>サーバーゴースト名</dd>
+						<dt>Reference2</dt>
+						<dd>サーバーのイベント名</dd>
+					</dl>
+					<section id="reference_OnPoker">
+						<h1>POKER/1.0におけるReference3以降の追加情報</h1>
+						<dl class="reference">
+							<dt>Reference3</dt>
+							<dd>hello（参加申請をする。断られることもある。）</dd>
+						</dl>
+						<dl class="reference">
+							<dt>Reference3</dt>
+							<dd>action（Reference4以降に使用可能なアクションが入っている。）</dd>
+							<dt>Reference*</dt>
+							<dd>使用可能なアクションはbet,raise,allin,check,call,foldの6つの内のいくつか。<br />
+								返答しない場合は自動的にfoldになるので注意。<br />
+								bet/raiseする場合はレイズ額も送る必要がある。</dd>
+						</dl>
+					</section>
+				</dd>
+			</dl>
+			<dl id="OnPokerNotify">
+				<dt class="entry">OnPokerNotify</dt>
+				<dd class="entry">
+					<p>応答する必要の無いイベント。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>プロトコルバージョン(POKER/1.0)</dd>
+					</dl>
+					<section id="reference_OnPokerNotify">
+						<h1>POKER/1.0におけるReference1以降の追加情報</h1>
+						<dl class="reference">
+							<dt>Reference1</dt>
+							<dd>game_start</dd>
+							<dt>Reference*</dt>
+							<dd>参加できたゴースト名</dd>
+						</dl>
+						<dl class="reference">
+							<dt>Reference1</dt>
+							<dd>round_start</dd>
+							<dt>Reference2</dt>
+							<dd>ブラインドの金額</dd>
+							<dt>Reference*</dt>
+							<dd>ゴースト名(バイト値1)スタック</dd>
+						</dl>
+						<dl class="reference">
+							<dt>Reference1</dt>
+							<dd>hand</dd>
+							<dt>Reference2</dt>
+							<dd>配られたカードの情報</dd>
+							<dt>Reference3</dt>
+							<dd>配られたカードの情報<br />
+								スートは頭文字(S,H,C,D)の4つのいずれか、その後に数字が続く。<br />
+								例:<br />
+								Reference2: S1<br />
+								Reference3: H12<br />
+								この形式はFLIPでも一緒。
+							</dd>
+						</dl>
+						<dl class="reference">
+							<dt>Reference1</dt>
+							<dd>flip</dd>
+							<dt>Reference2</dt>
+							<dd>現在のポット</dd>
+							<dt>Reference*</dt>
+							<dd>コミュニティカードの情報<br />
+								プリフロップならReference3以降は存在しない</dd>
+						</dl>
+						<dl class="reference">
+							<dt>Reference1</dt>
+							<dd>blind_bet</dd>
+							<dt>Reference2</dt>
+							<dd>強制ベットの金額<br />
+								SBやBBでの強制ベットをしたことが通知される。</dd>
+						</dl>
+						<dl class="reference">
+							<dt>Reference1</dt>
+							<dd>bet（アクションを行ったプレイヤーとベット周りの情報。）</dd>
+							<dt>Reference2</dt>
+							<dd>現在のベット総額</dd>
+							<dt>Reference3</dt>
+							<dd>現在のベット額</dd>
+							<dt>Reference4</dt>
+							<dd>アクションを行ったプレイヤーのゴースト名</dd>
+							<dt>Reference5</dt>
+							<dd>行ったアクション</dd>
+						</dl>
+						<dl class="reference">
+							<dt>Reference1</dt>
+							<dd>show_down（ショーダウン時のカード情報が送られてくる。）</dd>
+							<dt>Reference*</dt>
+							<dd>ゴースト名(バイト値1)1枚目のカード(バイト値1)2枚目のカード</dd>
+						</dl>
+						<dl class="reference">
+							<dt>Reference1</dt>
+							<dd>round_result（そのラウンドの勝者、および参加者の残りスタックの情報。）</dd>
+							<dt>Reference2</dt>
+							<dd>現在のラウンドの勝者がバイト値1区切りで入っている。</dd>
+							<dt>Reference*</dt>
+							<dd>ゴースト名(バイト値1)スタック<br />
+								基本的に勝者は1人だが2人以上になるケースもある。<br />
+								また、スタックが0になったのはここでしか通知しないため注意。</dd>
+						</dl>
+						<dl class="reference">
+							<dt>Reference1</dt>
+							<dd>game_result</dd>
+							<dt>Reference2</dt>
+							<dd>ゲームの勝者のゴースト名</dd>
+						</dl>
+					</section>
+				</dd>
+			</dl>
+		</section>
+		<section class="category ghost">
+			<h1>ゴースト「フォーリナー」サプリメント「march of phantasma」</h1>
+			<ul class="caption link">
+				<li>公開元：<a href="http://rakudaya.sakura.tv/mop/beta.html">http://rakudaya.sakura.tv/mop/beta.html</a></li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="OnMopClear">
+				<dt class="entry">OnMopClear</dt>
+				<dd class="entry">
+					<p>マップクリア時に通知。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>クリア時のメンバーをバイト値1区切り（固有ユニットのみ）。</dd>
+						<dt>Reference1</dt>
+						<dd>クリアしたマップ名。</dd>
+					</dl>
+				</dd>
+			</dl>
+		</section>
+		<section class="category ghost">
+			<h1>ゴースト「Needle」</h1>
+			<ul class="caption link">
+				<li>公開元：<a href="https://ukagaka.zichqec.com/ghost/needle">https://ukagaka.zichqec.com/ghost/needle</a></li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="OnNeedlePoke">
+				<dt class="entry">OnNeedlePoke</dt>
+				<dd class="entry">
+					<p>Occurs when Needle "pokes" another ghost (by overlapping them). If Needle is overlapping multiple scopes simultaneously, the event will be sent once for each scope.</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>The ID of the scope that was poked. 0 for the main character, 1 for the side character, 2 and onwards for additional characters.</dd>
+						<dt>Reference1</dt>
+						<dd>The name of the shell Needle is currently using.</dd>
+					</dl>
+				</dd>
+			</dl>
 		</section>
 		<section class="category plugin">
 			<h1>プラグイン「バーチャルビールかけ（BeerShower）」</h1>
@@ -654,6 +1205,562 @@
 				</dd>
 			</dl>
 		</section>
+		<section class="category plugin">
+			<h1>プラグイン「Weather Station」</h1>
+			<ul class="caption link">
+				<li>公開元：<a href="https://ukagaka.zichqec.com/plugin/weather_station">https://ukagaka.zichqec.com/plugin/weather_station</a></li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="OnWeatherStation.Weather">
+				<dt class="entry">OnWeatherStation.Weather</dt>
+				<dd class="entry">
+					<p>Sends information about the current weather conditions to all open ghosts. This event occurs every hour, every time another ghost boots, and any time any ghost requests it with \![raiseplugin].</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>Weather condition. <a href="#caption_weather_station_conditions">※See below</a> for a list of possible weather conditions.</dd>
+						<dt>Reference1</dt>
+						<dd>Weather condition icon filename. To be used with weatherapi's <a href="https://cdn.weatherapi.com/weather.zip">weather icon pack</a>.</dd>
+						<dt>Reference2</dt>
+						<dd>Weather condition code. <a href="#caption_weather_station_conditions">※See below</a> for a list of possible weather condition codes.</dd>
+						<dt>Reference3</dt>
+						<dd>If it is daytime or not. 1 if the sun is up, 0 if the sun is down.</dd>
+						<dt>Reference4</dt>
+						<dd>Temperature in Fahrenheit.</dd>
+						<dt>Reference5</dt>
+						<dd>Temperature in Celsius.</dd>
+						<dt>Reference6</dt>
+						<dd>"Feels like" temperature in Fahrenheit.</dd>
+						<dt>Reference7</dt>
+						<dd>"Feels like" temperature in Celsius.</dd>
+						<dt>Reference8</dt>
+						<dd>Humidity as a percentage.</dd>
+						<dt>Reference9</dt>
+						<dd>Wind speed in miles per hour.</dd>
+						<dt>Reference10</dt>
+						<dd>Wind speed in kilometers per hour.</dd>
+						<dt>Reference11</dt>
+						<dd>Wind direction as a 16 point compass. (e.g.: NNE for north/northeast.)</dd>
+						<dt>Reference12</dt>
+						<dd>Wind direction in degrees.</dd>
+						<dt>Reference13</dt>
+						<dd>Wind gust speed in miles per hour.</dd>
+						<dt>Reference14</dt>
+						<dd>Wind gust speed in kilometers per hour.</dd>
+						<dt>Reference15</dt>
+						<dd>Precipitation in inches.</dd>
+						<dt>Reference16</dt>
+						<dd>Precipitation in millimeters.</dd>
+						<dt>Reference17</dt>
+						<dd>Cloud cover as a percentage.</dd>
+						<dt>Reference18</dt>
+						<dd>"Will it rain today". 1 for yes, 0 for no. Same information as the "Will it rain today" in OnWeatherStation.Forecast.Day.</dd>
+						<dt>Reference19</dt>
+						<dd>Chance of rain today, as a percentage. Same information as the chance of rain in OnWeatherStation.Forecast.Day.</dd>
+						<dt>Reference20</dt>
+						<dd>"Will it snow today". 1 for yes, 0 for no. Same information as the "Will it snow today" in OnWeatherStation.Forecast.Day.</dd>
+						<dt>Reference21</dt>
+						<dd>Chance of snow today, as a percentage. Same information as the chance of snow in OnWeatherStation.Forecast.Day.</dd>
+						<dt>Reference22</dt>
+						<dd>Visibility in miles.</dd>
+						<dt>Reference23</dt>
+						<dd>Visibility in kilometers.</dd>
+						<dt>Reference24</dt>
+						<dd>Pressure in inches.</dd>
+						<dt>Reference25</dt>
+						<dd>Pressure in millibars.</dd>
+						<dt>Reference26</dt>
+						<dd>UV index.</dd>
+						<dt>Reference27</dt>
+						<dd>CO (Carbon Monoxide) in μg/m3 (Micrograms per cubic meter).</dd>
+						<dt>Reference28</dt>
+						<dd>O3 (Ozone) in μg/m3 (Micrograms per cubic meter).</dd>
+						<dt>Reference29</dt>
+						<dd>NO2 (Nitrogen Dioxide) in μg/m3 (Micrograms per cubic meter).</dd>
+						<dt>Reference30</dt>
+						<dd>SO2 (Sulfur Dioxide) in μg/m3 (Micrograms per cubic meter).</dd>
+						<dt>Reference31</dt>
+						<dd>PM2.5 (Particulate Matter smaller than 2.5 microns in diameter) in μg/m3 (Micrograms per cubic meter).</dd>
+						<dt>Reference32</dt>
+						<dd>PM10 (Particulate Matter smaller than 10 microns in diameter) in μg/m3 (Micrograms per cubic meter).</dd>
+						<dt>Reference33</dt>
+						<dd>US EPA index. 1 means Good, 2 means Moderate, 3 means Unhealthy for sensitive group, 4 means Unhealthy, 5 means Very unhealthy, 6 means Hazardous.</dd>
+						<dt>Reference34</dt>
+						<dd>UK Defra Index. <a href="#caption_weather_station_uk_defra_index">※See below</a> for details.</dd>
+						<dt>Reference35</dt>
+						<dd>The user's choice of units (Imperial or Metric).</dd>
+						<dt>Reference36</dt>
+						<dd>The time the plugin last updated the weather data, in seconds since EPOCH (1970/1/1 00:00:00).</dd>
+						<dt>Reference37</dt>
+						<dd>The current version number of the plugin.</dd>
+						<dt>Reference38</dt>
+						<dd>The user's location name. Only available if the user has chosen to share their location data.</dd>
+						<dt>Reference39</dt>
+						<dd>The url for the user's location, to be used with the API. Only available if the user has chosen to share their location data.</dd>
+						<dt>Reference40</dt>
+						<dd>The user's latitude. Only available if the user has chosen to share their location data.</dd>
+						<dt>Reference41</dt>
+						<dd>The user's longitude. Only available if the user has chosen to share their location data.</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="OnWeatherStation.Astro">
+				<dt class="entry">OnWeatherStation.Astro</dt>
+				<dd class="entry">
+					<p>Sends information about the sun and moon to all open ghosts. Must be called with \![raiseplugin]. An additional argument can be sent to specify which day's data should be sent. 0 for today, 1 for tomorrow, 2 for the day after tomorrow. If no argument is given, it will default to today.</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>The day the following information is for. 0 for today, 1 for tomorrow, 2 for the day after tomorrow.</dd>
+						<dt>Reference1</dt>
+						<dd>Sunrise time, given as 12 hour time with the format ##:## *M</dd>
+						<dt>Reference2</dt>
+						<dd>Sunset time, given as 12 hour time with the format ##:## *M</dd>
+						<dt>Reference3</dt>
+						<dd>Moonrise time, given as 12 hour time with the format ##:## *M</dd>
+						<dt>Reference4</dt>
+						<dd>Moonset time, given as 12 hour time with the format ##:## *M</dd>
+						<dt>Reference5</dt>
+						<dd>Sunrise time, given as 24 hour time with the format ##:##</dd>
+						<dt>Reference6</dt>
+						<dd>Sunset time, given as 24 hour time with the format ##:##</dd>
+						<dt>Reference7</dt>
+						<dd>Moonrise time, given as 24 hour time with the format ##:##</dd>
+						<dt>Reference8</dt>
+						<dd>Moonset time, given as 24 hour time with the format ##:##</dd>
+						<dt>Reference9</dt>
+						<dd>Moon phase as a string. Can be "New Moon", "Waxing Crescent". "First Quarter", "Waxing Gibbous", "Full Moon", "Waning Gibbous", "Last Quarter", or "Waning Crescent".</dd>
+						<dt>Reference10</dt>
+						<dd>Moon phase number. Numbers correspond to the following phases.
+						<ul>
+							<li>0 - New Moon</li>
+							<li>1 - Waxing Crescent</li>
+							<li>2 - First Quarter</li>
+							<li>3 - Waxing Gibbous</li>
+							<li>4 - Full Moon</li>
+							<li>5 - Waning Gibbous</li>
+							<li>6 - Last Quarter</li>
+							<li>7 - Waning Crescent</li>
+						</ul>
+						</dd>
+						<dt>Reference11</dt>
+						<dd>Moon illumination as a percentage.</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="OnWeatherStation.Alerts">
+				<dt class="entry">OnWeatherStation.Alerts</dt>
+				<dd class="entry">
+					<p>Sends information about weather alerts to all open ghosts. Must be called with \![raiseplugin]. Will return nothing if there are no alerts.</p>
+					<dl class="reference">
+						<dt>Reference*</dt>
+						<dd>An array containing information for a weather alert. Some elements may not be filled. Elements are separated by a 1 byte value.
+						<ul>
+							<!--I have no idea what a lot of these mean! If anyone else knows please feel free to detail it.-->
+							<li>[0] - Headline</li>
+							<li>[1] - Type of alert</li>
+							<li>[2] - Severity</li>
+							<li>[3] - Urgency</li>
+							<li>[4] - Areas covered</li>
+							<li>[5] - Category</li>
+							<li>[6] - Certainty</li>
+							<li>[7] - Event</li>
+							<li>[8] - Note</li>
+							<li>[9] - Effective time</li>
+							<li>[10] - Expires time</li>
+							<li>[11] - Description</li>
+							<li>[12] - Instructions</li>
+						</ul>
+						</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="OnWeatherStation.Forecast.Day">
+				<dt class="entry">OnWeatherStation.Forecast.Day</dt>
+				<dd class="entry">
+					<p>Sends information about the overall forecast for a day to all open ghosts. Must be called with \![raiseplugin]. An additional argument can be sent to specify which day's data should be sent. 0 for today, 1 for tomorrow, 2 for the day after tomorrow. If no argument is given, it will default to today.</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>The day the following information is for. 0 for today, 1 for tomorrow, 2 for the day after tomorrow.</dd>
+						<dt>Reference1</dt>
+						<dd>Maximum temperature for the day, in Fahrenheit.</dd>
+						<dt>Reference2</dt>
+						<dd>Maximum temperature for the day, in Celsius.</dd>
+						<dt>Reference3</dt>
+						<dd>Minimum temperature for the day, in Fahrenheit.</dd>
+						<dt>Reference4</dt>
+						<dd>Minimum temperature for the day, in Celsius.</dd>
+						<dt>Reference5</dt>
+						<dd>Average temperature for the day, in Fahrenheit.</dd>
+						<dt>Reference6</dt>
+						<dd>Average temperature for the day, in Celsius.</dd>
+						<dt>Reference7</dt>
+						<dd>Average humidity for the day, as a percentage.</dd>
+						<dt>Reference8</dt>
+						<dd>Maximum windspeed for the day, in mph.</dd>
+						<dt>Reference9</dt>
+						<dd>Maximum windspeed for the day, in kph.</dd>
+						<dt>Reference10</dt>
+						<dd>Total precipitation for the day, in inches.</dd>
+						<dt>Reference11</dt>
+						<dd>Total precipitation for the day, in millimeters.</dd>
+						<dt>Reference12</dt>
+						<dd>"Will it rain this day", 1 if yes, 0 if no.</dd>
+						<dt>Reference13</dt>
+						<dd>Chance that it will rain this day, as a percentage.</dd>
+						<dt>Reference14</dt>
+						<dd>"Will it snow this day", 1 if yes, 0 if no.</dd>
+						<dt>Reference15</dt>
+						<dd>Chance that it will snow this day, as a percentage.</dd>
+						<dt>Reference16</dt>
+						<dd>Average visiblity for the day, in miles.</dd>
+						<dt>Reference17</dt>
+						<dd>Average visiblity for the day, in kilometers.</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="OnWeatherStation.Forecast.Hourly">
+				<dt class="entry">OnWeatherStation.Forecast.Hourly</dt>
+				<dd class="entry">
+					<p>Sends information about the hour-by-hour forecast for a day to all open ghosts. Must be called with \![raiseplugin]. An additional argument can be sent to specify which day's data should be sent. 0 for today, 1 for tomorrow, 2 for the day after tomorrow. If no argument is given, it will default to today.</p>
+					<dl class="reference">
+						<dt>Reference0～23</dt>
+						<dd>A comma separated array containing forecast information. The number of the reference corresponds to the number of the hour the data is for, in 24 hour time (e.g.: reference0 is for 00:00/12AM, reference14 is for 14:00/2PM).
+						<ul>
+							<li>[0] - Date and time the information is for.</li>
+							<li>[1] - "Is it daytime". 1 if the sun is up, 0 if the sun is down.</li>
+							<li>[2] - Temperature in Fahrenheit.</li>
+							<li>[3] - Temperature in Celsius.</li>
+							<li>[4] - "Feels like" temperature in Fahrenheit.</li>
+							<li>[5] - "Feels like" temperature in Celsius.</li>
+							<li>[6] - Humidity as a percentage.</li>
+							<li>[7] - Wind speed in miles per hour.</li>
+							<li>[8] - Wind speed in kilometers per hour.</li>
+							<li>[9] - Wind direction as a 16 point compass (e.g.: NNW for north/northwest).</li>
+							<li>[10] - Wind direction in degrees.</li>
+							<li>[11] - Wind gusts in miles per hour.</li>
+							<li>[12] - Wind gusts in kilometers per hour.</li>
+							<li>[13] - Precipitation in inches.</li>
+							<li>[14] - Precipitation in millimeters.</li>
+							<li>[15] - Cloud cover as a percentage.</li>
+							<li>[16] - "Will it rain", 1 if yes, 0 if no.</li>
+							<li>[17] - Chance of rain as a percentage.</li>
+							<li>[18] - "Will it snow", 1 if yes, 0 if no.</li>
+							<li>[19] - Chance of snow as a percentage.</li>
+							<li>[20] - Visibility in miles.</li>
+							<li>[21] - Visibility in kilometers.</li>
+							<li>[22] - Wind chill in Fahrenheit.</li>
+							<li>[23] - Wind chill in Celsius.</li>
+							<li>[24] - Heat index in Fahrenheit.</li>
+							<li>[25] - Heat index in Celsius.</li>
+							<li>[26] - Dew point in Fahrenheit.</li>
+							<li>[27] - Dew point in Celsius.</li>
+							<li>[28] - Pressure in inches.</li>
+							<li>[29] - Pressure in millibars.</li>
+							<li>[30] - UV index.</li>
+						</ul>
+						</dd>
+						<dt>Reference24</dt>
+						<dd>The day the preceding information is for. 0 for today, 1 for tomorrow, 2 for the day after tomorrow.</dd>
+					</dl>
+				</dd>
+			</dl>
+			<dl id="OnWeatherStation.Error">
+				<dt class="entry">OnWeatherStation.Error</dt>
+				<dd class="entry">
+					<p>Sends error information to all open ghosts. This event is sent in place of the previous events if there is an error of any kind.</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>The error message. <a href="#caption_weather_station_errors">※See below</a> for possible error messages.</dd>
+						<dt>Reference1</dt>
+						<dd>A more descriptive error message, provided by weatherapi.com. <em>These error messages do not match the online documentation for weatherapi and should not be used for identifying errors.</em></dd>
+						<dt>Reference2</dt>
+						<dd>The error code, as listed on weatherapi.com's documentation.</dd>
+						<dt>Reference3</dt>
+						<dd>The time the plugin last attempted to update the weather data, in seconds since EPOCH (1970/1/1 00:00:00).</dd>
+						<dt>Reference4</dt>
+						<dd>The current version number of the plugin.</dd>
+						<dt>Reference5</dt>
+						<dd>1 if there is a plugin update available, 0 otherwise.</dd>
+					</dl>
+				</dd>
+			</dl>
+			<div class="caption" id="caption_weather_station_conditions">
+				<h1>Weather Condition & Code List</h1>
+				<p>A list of conditions can be downloaded from <a href="https://www.weatherapi.com/docs/">weatherapi's documentation page</a>. This list is also available in other languages, but information from the plugin will always be sent in english.</p>
+				<dl>
+					<dt>1000</dt>
+					<dd>
+						Sunny (If the sun is down, it will be "Clear" instead.)
+					</dd>
+					<dt>1003</dt>
+					<dd>
+						Partly cloudy
+					</dd>
+					<dt>1006</dt>
+					<dd>
+						Cloudy
+					</dd>
+					<dt>1009</dt>
+					<dd>
+						Overcast
+					</dd>
+					<dt>1030</dt>
+					<dd>
+						Mist
+					</dd>
+					<dt>1063</dt>
+					<dd>
+						Patchy rain possible
+					</dd>
+					<dt>1066</dt>
+					<dd>
+						Patchy snow possible
+					</dd>
+					<dt>1069</dt>
+					<dd>
+						Patchy sleet possible
+					</dd>
+					<dt>1072</dt>
+					<dd>
+						Patchy freezing drizzle possible
+					</dd>
+					<dt>1087</dt>
+					<dd>
+						Thundery outbreaks possible
+					</dd>
+					<dt>1114</dt>
+					<dd>
+						Blowing snow
+					</dd>
+					<dt>1117</dt>
+					<dd>
+						Blizzard
+					</dd>
+					<dt>1135</dt>
+					<dd>
+						Fog
+					</dd>
+					<dt>1147</dt>
+					<dd>
+						Freezing fog
+					</dd>
+					<dt>1150</dt>
+					<dd>
+						Patchy light drizzle
+					</dd>
+					<dt>1153</dt>
+					<dd>
+						Light drizzle
+					</dd>
+					<dt>1168</dt>
+					<dd>
+						Freezing drizzle
+					</dd>
+					<dt>1171</dt>
+					<dd>
+						Heavy freezing drizzle
+					</dd>
+					<dt>1180</dt>
+					<dd>
+						Patchy light rain
+					</dd>
+					<dt>1183</dt>
+					<dd>
+						Light rain
+					</dd>
+					<dt>1186</dt>
+					<dd>
+						Moderate rain at times
+					</dd>
+					<dt>1189</dt>
+					<dd>
+						Moderate rain
+					</dd>
+					<dt>1192</dt>
+					<dd>
+						Heavy rain at times
+					</dd>
+					<dt>1195</dt>
+					<dd>
+						Heavy rain
+					</dd>
+					<dt>1198</dt>
+					<dd>
+						Light freezing rain
+					</dd>
+					<dt>1201</dt>
+					<dd>
+						Moderate or heavy freezing rain
+					</dd>
+					<dt>1204</dt>
+					<dd>
+						Light sleet
+					</dd>
+					<dt>1207</dt>
+					<dd>
+						Moderate or heavy sleet
+					</dd>
+					<dt>1210</dt>
+					<dd>
+						Patchy light snow
+					</dd>
+					<dt>1213</dt>
+					<dd>
+						Light snow
+					</dd>
+					<dt>1216</dt>
+					<dd>
+						Patchy moderate snow
+					</dd>
+					<dt>1219</dt>
+					<dd>
+						Moderate snow
+					</dd>
+					<dt>1222</dt>
+					<dd>
+						Patchy heavy snow
+					</dd>
+					<dt>1225</dt>
+					<dd>
+						Heavy snow
+					</dd>
+					<dt>1237</dt>
+					<dd>
+						Ice pellets
+					</dd>
+					<dt>1240</dt>
+					<dd>
+						Light rain shower
+					</dd>
+					<dt>1243</dt>
+					<dd>
+						Moderate or heavy rain shower
+					</dd>
+					<dt>1246</dt>
+					<dd>
+						Torrential rain shower
+					</dd>
+					<dt>1249</dt>
+					<dd>
+						Light sleet showers
+					</dd>
+					<dt>1252</dt>
+					<dd>
+						Moderate or heavy sleet showers
+					</dd>
+					<dt>1255</dt>
+					<dd>
+						Light snow showers
+					</dd>
+					<dt>1258</dt>
+					<dd>
+						Moderate or heavy snow showers
+					</dd>
+					<dt>1261</dt>
+					<dd>
+						Light showers of ice pellets
+					</dd>
+					<dt>1264</dt>
+					<dd>
+						Moderate or heavy showers of ice pellets
+					</dd>
+					<dt>1273</dt>
+					<dd>
+						Patchy light rain with thunder
+					</dd>
+					<dt>1276</dt>
+					<dd>
+						Moderate or heavy rain with thunder
+					</dd>
+					<dt>1279</dt>
+					<dd>
+						Patchy light snow with thunder
+					</dd>
+					<dt>1282</dt>
+					<dd>
+						Moderate or heavy snow with thunder
+					</dd>
+				</dl>
+			</div>
+			<div class="caption" id="caption_weather_station_uk_defra_index">
+				<h1>UK Defra Index reference</h1>
+				<table>
+					<tr>
+						<th>Index</th>
+						<td>1</td>
+						<td>2</td>
+						<td>3</td>
+						<td>4</td>
+						<td>5</td>
+						<td>6</td>
+						<td>7</td>
+						<td>8</td>
+						<td>9</td>
+						<td>10</td>
+					</tr>
+					<tr>
+						<th>Band</th>
+						<td>Low</td>
+						<td>Low</td>
+						<td>Low</td>
+						<td>Moderate</td>
+						<td>Moderate</td>
+						<td>Moderate</td>
+						<td>High</td>
+						<td>High</td>
+						<td>High</td>
+						<td>Very High</td>
+					</tr>
+					<tr>
+						<th>µgm-3</th>
+						<td>0-11</td>
+						<td>12-23</td>
+						<td>24-35</td>
+						<td>36-41</td>
+						<td>42-47</td>
+						<td>48-53</td>
+						<td>54-58</td>
+						<td>59-64</td>
+						<td>65-70</td>
+						<td>71 or more</td>
+					</tr>
+				</table>
+			</div>
+			<div class="caption" id="caption_weather_station_errors">
+				<h1>Reason for Error</h1>
+				<dl>
+					<dt>no_location</dt>
+					<dd>
+						The user has not added their location, or has removed it.
+					</dd>
+					<dt>location_invalid</dt>
+					<dd>
+						The user's location is invalid and data cannot be gathered.
+					</dd>
+					<dt>api_quota_exceeded</dt>
+					<dd>
+						The 1 million free API calls per month has been exceeded.
+					</dd>
+					<dt>api_key_disabled</dt>
+					<dd>
+						The API key has been disabled by the plugin developer. Please check if a plugin update is available to provide a new key.
+					</dd>
+					<dt>api_internal_error</dt>
+					<dd>
+						The API responded with an internal error.
+					</dd>
+					<dt>no_api_response</dt>
+					<dd>
+						The API did not respond, or the SAORI used by the plugin failed to work.
+					</dd>
+					<dt>other</dt>
+					<dd>
+						Any other error sent by the API. reference1 will have the error message provided by the API.
+					</dd>
+				</dl>
+			</div>
+		</section>
 		<section class="category saori">
 			<h1>SAORI「httpc.dll」</h1>
 			<ul class="caption link">
@@ -676,138 +1783,6 @@
 						<dt>Reference*</dt>
 						<dd>実行した機能の戻り値。</dd>
 					</dl>
-				</dd>
-			</dl>
-		</section>
-		<section class="category other">
-			<h1>外部アプリ汎用イベント</h1>
-			<dl id="OnApplicationBoot">
-				<dt class="entry">OnApplicationBoot</dt>
-				<dd class="entry">
-					<p>外部アプリケーションが起動した際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>アプリケーション名。</dd>
-						<dt>Reference1</dt>
-						<dd>アプリケーションの情報。</dd>
-					</dl>
-					<ul class="supported-baseware">
-						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
-						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
-					</ul>
-				</dd>
-			</dl>
-			<dl id="OnApplicationClose">
-				<dt class="entry">OnApplicationClose</dt>
-				<dd class="entry">
-					<p>外部アプリケーションが終了した際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>アプリケーション名。</dd>
-						<dt>Reference1</dt>
-						<dd>アプリケーションの情報。</dd>
-					</dl>
-					<ul class="supported-baseware">
-						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
-						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
-					</ul>
-				</dd>
-			</dl>
-			<dl id="OnApplicationExist">
-				<dt class="entry">OnApplicationExist</dt>
-				<dd class="entry">
-					<p>外部アプリケーションの存在を通知された際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>アプリケーション名。</dd>
-						<dt>Reference1</dt>
-						<dd>アプリケーションの情報。</dd>
-					</dl>
-					<ul class="supported-baseware">
-						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
-						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
-					</ul>
-				</dd>
-			</dl>
-			<dl id="OnApplicationVersion">
-				<dt class="entry">OnApplicationVersion</dt>
-				<dd class="entry">
-					<p>外部アプリケーションのバージョン情報を通知された際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>アプリケーション名。</dd>
-						<dt>Reference1</dt>
-						<dd>アプリケーションの情報。</dd>
-						<dt>Reference2</dt>
-						<dd>バージョン番号。</dd>
-						<dt>Reference3</dt>
-						<dd>著作権。</dd>
-						<dt>Reference4</dt>
-						<dd>開発元のURL。</dd>
-					</dl>
-					<ul class="supported-baseware">
-						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
-						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
-					</ul>
-				</dd>
-			</dl>
-			<dl id="OnApplicationOperationFinish">
-				<dt class="entry">OnApplicationOperationFinish</dt>
-				<dd class="entry">
-					<p>外部アプリケーションか何らかの処理が完了した際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>アプリケーション名。</dd>
-						<dt>Reference1</dt>
-						<dd>処理の内容。</dd>
-						<dt>Reference2</dt>
-						<dd>処理の対象。</dd>
-					</dl>
-					<ul class="supported-baseware">
-						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
-						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
-					</ul>
-				</dd>
-			</dl>
-			<dl id="OnApplicationFileOpen">
-				<dt class="entry">OnApplicationFileOpen</dt>
-				<dd class="entry">
-					<p>外部アプリケーションがドキュメントファイルを開いた際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>アプリケーション名。</dd>
-						<dt>Reference1</dt>
-						<dd>ファイルのフルパス。</dd>
-					</dl>
-					<ul class="supported-baseware">
-						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
-						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
-					</ul>
-				</dd>
-			</dl>
-			<dl id="OnWebsiteUpdateNotify">
-				<dt class="entry">OnWebsiteUpdateNotify</dt>
-				<dd class="entry">
-					<p>ウェブサイトの更新・新着情報を通知された際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>ウェブサイト名。</dd>
-						<dt>Reference1</dt>
-						<dd>最終更新日時。</dd>
-						<dt>Reference2</dt>
-						<dd>更新内容。</dd>
-					</dl>
-					<ul class="supported-baseware">
-						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
-						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
-					</ul>
 				</dd>
 			</dl>
 		</section>
@@ -2242,536 +3217,6 @@
 				</dd>
 			</dl>
 		</section>
-		<section class="category ghost">
-			<h1>ゴースト間汎用イベント</h1>
-			<dl id="OnRequestValues">
-				<dt class="entry">OnRequestValues</dt>
-				<dd class="entry">
-					<p>他ゴーストが任意に送信した際に発生。<br />このイベントが送られた時、\[raiseother]でOnGetValuesイベントを送信する必要がある。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>送信したゴースト名。</dd>
-						<dt>Reference1</dt>
-						<dd>要求する変数名(key)。Reference2以降も同様に要求する変数がある限り続く。</dd>
-					</dl>
-					<ul class="supported-baseware">
-						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-					</ul>
-				</dd>
-			</dl>
-			<dl id="OnGetValues">
-				<dt class="entry">OnGetValues</dt>
-				<dd class="entry">
-					<p>OnRequestValuesを受けた際に返すべきイベント。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>送信するゴースト名。</dd>
-						<dt>Reference1</dt>
-						<dd>key=value(keyはOnRequestValuesで受け取った変数名、valueはその値)。Reference2以降も同様に要求された変数がある限り続く。存在しない変数は返さない。OnRequestValuesで送られた順序に依存しない。</dd>
-					</dl>
-					<ul class="supported-baseware">
-						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-					</ul>
-				</dd>
-			</dl>
-			<div class="caption">
-				<h1>要求されるプロパティ名一覧</h1>
-				<ul>
-					<li>キャラクター名</li>
-					<li>世代</li>
-					<li>年齢層</li>
-					<li>性別</li>
-					<li>種族</li>
-					<li>種族タイプ</li>
-					<li>行動タイプ</li>
-					<li>プロフィール</li>
-					<li>カード画像パス</li>
-					<li>LIFE</li>
-					<li>STR</li>
-					<li>DEX</li>
-					<li>AGL</li>
-					<li>MIN</li>
-					<li>INT</li>
-					<li>SEN</li>
-					<li>NOB</li>
-				</ul>
-			</div>
-		</section>
-		<section class="category ghost">
-			<h1>ゴースト「ぬるぽ いんたーはい」</h1>
-			<ul class="caption link">
-				<li>公開元：閉鎖</li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="OnTalkRequest">
-				<dt class="entry">OnTalkRequest</dt>
-				<dd class="entry">
-					<p>ぬるぽ　いんたーはいからトークを求められた際に発生。</p>
-				</dd>
-			</dl>
-		</section>
-		<section class="category ghost">
-			<h1>ゴースト「The Hand」</h1>
-			<ul class="caption link">
-				<li>公開元：<a href="http://ukiya.sakura.ne.jp/">http://ukiya.sakura.ne.jp/</a></li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="OnHandActivate">
-				<dt class="entry">OnHandActivate</dt>
-				<dd class="entry">
-					<p>The Handが他ゴーストを触りに行くまたは触り終わった際に発生。<br />触っている間、Sender:The Handでゴーストに(OnMouseMove|OnMouseDoubleClick|OnMouseWheel)イベントを送る。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>通常触り開始：NormalStart<br />通常触り終了：NormalEnd<br />必殺技開始：SuperStart<br />必殺技途中：SuperContinue<br />必殺技終了：SuperEnd<br />必殺技途中でホーミング発動：SuperHoming</dd>
-						<dt>Reference1</dt>
-						<dd>当たり判定名。<br />停止された場合はescaped。<br />必殺技の場合は1～4。</dd>
-						<dt>Reference2</dt>
-						<dd>相手に起きるイベント。<br />通常時：(OnMouseMove|OnMouseDoubleClick|OnMouseWheel)<br />必殺技中：触った回数<br />必殺技終了時：(MAX触り回数|escaped|nocollision|attacked|deleted)</dd>
-						<dt>Reference3</dt>
-						<dd>触りに行く際のスクリプト。<br />必殺技中は当たり判定名。</dd>
-						<dt>Reference4</dt>
-						<dd>シェル番号。</dd>
-					</dl>
-				</dd>
-			</dl>
-		</section>
-		<section class="category ghost">
-			<h1>ゴースト「ごーすとじてん」</h1>
-			<ul class="caption link">
-				<li>公開元：<a href="https://github.com/nikolat/ghostbook">https://github.com/nikolat/ghostbook</a></li>
-				<li>関連：<a href="http://spoon.if.land.to/wiki/index.php?%A4%B4%A1%BC%A4%B9%A4%C8%A4%B8%A4%C6%A4%F3">http://spoon.if.land.to/wiki/index.php?%A4%B4%A1%BC%A4%B9%A4%C8%A4%B8%A4%C6%A4%F3</a></li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="OnJitenBattle">
-				<dt class="entry">OnJitenBattle</dt>
-				<dd class="entry">
-					<p>ゴーストが行う模擬戦の毎ターン発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>送信したゴーストの\0名。</dd>
-						<dt>Reference1</dt>
-						<dd>攻撃側キャラクタ名。</dd>
-						<dt>Reference2</dt>
-						<dd>防御側キャラクタ名。</dd>
-						<dt>Reference3</dt>
-						<dd>戦闘結果。<br />開始時：模擬戦闘開始<br />行動時：(物理攻撃成功|物理攻撃失敗|物理攻撃回避|物理攻撃ミス|精神攻撃成功|精神攻撃失敗|精神攻撃回避|精神攻撃ミス)</dd>
-						<dt>Reference4</dt>
-						<dd>ダメージ。</dd>
-						<dt>Reference5</dt>
-						<dd>攻撃側キャラクタLIFE。</dd>
-						<dt>Reference6</dt>
-						<dd>防御側キャラクタLIFE。</dd>
-						<dt>Reference7</dt>
-						<dd>Normal</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="OnJitenTagBattle">
-				<dt class="entry">OnJitenTagBattle</dt>
-				<dd class="entry">
-					<p>ゴーストが行う模擬戦の毎ターン発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>送信したゴーストの\0名。</dd>
-						<dt>Reference1</dt>
-						<dd>攻撃側キャラクタ名。</dd>
-						<dt>Reference2</dt>
-						<dd>防御側キャラクタ名。</dd>
-						<dt>Reference3</dt>
-						<dd>戦闘結果。<br />開始時：模擬戦闘開始<br />行動時：(物理攻撃成功|物理攻撃失敗|物理攻撃回避|物理攻撃ミス|精神攻撃成功|精神攻撃失敗|精神攻撃回避|精神攻撃ミス)</dd>
-						<dt>Reference4</dt>
-						<dd>ダメージ。</dd>
-						<dt>Reference5</dt>
-						<dd>攻撃側キャラクタLIFE。</dd>
-						<dt>Reference6</dt>
-						<dd>防御側キャラクタLIFE。</dd>
-						<dt>Reference7</dt>
-						<dd>Tag</dd>
-					</dl>
-				</dd>
-			</dl>
-		</section>
-		<section class="category ghost">
-			<h1>ゴースト「マギルトリエ」</h1>
-			<ul class="caption link">
-				<li>公開元：閉鎖</li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="OnMglBattle">
-				<dt class="entry">OnMglBattle</dt>
-				<dd class="entry">
-					<p>マギルトリエが行うバーチャルバトルの結果ごとに発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>バージョン情報。</dd>
-						<dt>Reference2</dt>
-						<dd>送信元ゴースト。</dd>
-						<dt>Reference3</dt>
-						<dd>Mglイベント名。</dd>
-						<dt>Reference*</dt>
-						<dd>Mglイベントに対する内容。</dd>
-					</dl>
-				</dd>
-			</dl>
-		</section>
-		<section class="category ghost">
-			<h1>ゴースト「カレー家族／沙紀と右近」</h1>
-			<ul class="caption link">
-				<li>公開元：<a href="http://curryfamily.me.land.to/ghost_saki.html">http://curryfamily.me.land.to/ghost_saki.html</a></li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="Send60stair_Call">
-				<dt class="entry">Send60stair_Call</dt>
-				<dd class="entry">
-					<p>カレー家族／沙紀と右近が同時起動しているゴーストをゲームに誘う際に発生。</p>
-				</dd>
-			</dl>
-			<dl id="Send60stair_Start">
-				<dt class="entry">Send60stair_Start</dt>
-				<dd class="entry">
-					<p>カレー家族／沙紀と右近がゲームを開始する際に発生。</p>
-					<ul class="supported-baseware">
-						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-					</ul>
-				</dd>
-			</dl>
-			<dl id="Send60stair_YourTurnStart">
-				<dt class="entry">Send60stair_YourTurnStart</dt>
-				<dd class="entry">
-					<p>カレー家族／沙紀と右近が行うゲーム中に自ゴーストの順番が来た際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>現在位置。</dd>
-						<dt>Reference1</dt>
-						<dd>マーキング位置。</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="Send60stair_Marking">
-				<dt class="entry">Send60stair_Marking</dt>
-				<dd class="entry">
-					<p>カレー家族／沙紀と右近が行うゲーム中にマーキングした際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>マーキング位置。</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="Send60stair_DiceRoll">
-				<dt class="entry">Send60stair_DiceRoll</dt>
-				<dd class="entry">
-					<p>カレー家族／沙紀と右近が行うゲーム中にゴーストがサイコロを振り、ドボンでない際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>第一サイコロの出目。</dd>
-						<dt>Reference1</dt>
-						<dd>第二サイコロの出目。</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="Send60stair_Dobon">
-				<dt class="entry">Send60stair_Dobon</dt>
-				<dd class="entry">
-					<p>カレー家族／沙紀と右近が行うゲーム中に参加ゴーストのいずれかがドボンした際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>ドボンしたゴースト名。</dd>
-						<dt>Reference1</dt>
-						<dd>ドボンしたゴーストの現在位置。</dd>
-						<dt>Reference2</dt>
-						<dd>ドボンしたゴーストのマーキング位置。</dd>
-						<dt>Reference3</dt>
-						<dd>サイコロの出目。</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="Send60stair_YourTurnEnd">
-				<dt class="entry">Send60stair_YourTurnEnd</dt>
-				<dd class="entry">
-					<p>カレー家族／沙紀と右近が行うゲーム中に自ゴーストのターンが終了した際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>現在位置。</dd>
-						<dt>Reference1</dt>
-						<dd>マーキング位置。</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="Send60stair_Goal">
-				<dt class="entry">Send60stair_Goal</dt>
-				<dd class="entry">
-					<p>カレー家族／沙紀と右近が行うゲーム中にいずれかのゴーストがゴールした際に発生。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>優勝したゴースト名。</dd>
-						<dt>Reference1</dt>
-						<dd>順位。</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="Send60stair_GameEnd">
-				<dt class="entry">Send60stair_GameEnd</dt>
-				<dd class="entry">
-					<p>カレー家族／沙紀と右近が行うゲーム終了時、順位を表示した後に発生。</p>
-				</dd>
-			</dl>
-			<dl id="Send60stair_GetStatus">
-				<dt class="entry">Send60stair_GetStatus</dt>
-				<dd class="entry">
-					<p>\[raiseother]で沙紀に送信するべきイベント。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>送信するゴーストの\0名。</dd>
-						<dt>Reference1</dt>
-						<dd>大胆さ。(0～60)</dd>
-					</dl>
-				</dd>
-			</dl>
-		</section>
-		<section class="category ghost">
-			<h1>ゴースト「奏でる日常の音色」</h1>
-			<ul class="caption link">
-				<li>公開元：<a href="http://ukananachi.blog98.fc2.com/">http://ukananachi.blog98.fc2.com/</a></li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="OnKanadeTeaPartyInfomationRequest">
-				<dt class="entry">OnKanadeTeaPartyInfomationRequest</dt>
-				<dd class="entry">
-					<p>お茶会開始前に、奏でる日常の音色から各ゴーストに通知されるイベント。<br />お茶会に参加するゴーストはこのイベントで直ちに、<br /><code>\![raiseother,かなで,<a href="#可変名の返信イベント">返信イベント名</a>,ゴーストの対応するお茶会バージョン番号,ゴーストの本体側名,<a href="#caption_kanade">※お茶会バージョンへの対応情報</a>]</code><br />のさくらスクリプトを実行する必要がある。<br />イベント内での、このスクリプトの実行以外のトークは非推奨。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>お茶会バージョン番号。</dd>
-						<dt>Reference1</dt>
-						<dd>返信イベントの送信先ゴースト本体側名（「かなで」に固定）。</dd>
-						<dt>Reference2</dt>
-						<dd>返信イベント名。</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="可変名の返信イベント">
-				<dt class="entry">可変名の返信イベント</dt>
-				<dd class="entry">
-					<p>OnKanadeTeaPartyInfomationRequestを受信したゴーストが、<em>奏でる日常の音色に対して</em>raiseotherで<em>通知する</em>イベント。<br />イベント名はOnKanadeTeaPartyInfomationRequestのreference2で通知されている。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>ゴーストの対応するお茶会バージョン番号</dd>
-						<dt>Reference1</dt>
-						<dd>ゴーストの本体側名</dd>
-						<dt>Reference2</dt>
-						<dd><a href="#caption_kanade">※お茶会バージョンへの対応情報</a></dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="OnKanadeTeaParty">
-				<dt class="entry">OnKanadeTeaParty</dt>
-				<dd class="entry">
-					<p>お茶会本体イベント。お茶会開始時に通知される。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>Reference1以降の組み合わせが実装されたお茶会のバージョン。</dd>
-						<dt>Reference1</dt>
-						<dd>お飲み物。</dd>
-						<dt>Reference2</dt>
-						<dd>お菓子</dd>
-						<dt>Reference*</dt>
-						<dd>Reference3以降は拡張情報。</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="OnKanadeTeaPartyEnd">
-				<dt class="entry">OnKanadeTeaPartyEnd</dt>
-				<dd class="entry">
-					<p>お茶会終了イベント。奏でる日常の音色が、お茶会終了トークをした後に通知される。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>実行されたお茶会のバージョン。</dd>
-					</dl>
-				</dd>
-			</dl>
-			<div class="caption" id="caption_kanade">
-				<p>※お茶会バージョンへの対応情報</p>
-				<dl>
-					<dt>対応</dt>
-					<dd>
-						「奏でる日常の音色」のバージョンよりもゴーストのバージョンが高いまたは同じなため、この「奏でる日常の音色」が提供するお茶会イベントに完全に対応しています。
-					</dd>
-					<dt>非対応</dt>
-					<dd>
-						「奏でる日常の音色」のバージョンよりもゴーストのバージョンが低いため、ゴーストのバージョンよりも高いバージョンのお茶会イベントは処理することができません。
-					</dd>
-					<dt>自動対応</dt>
-					<dd>
-						「奏でる日常の音色」のバージョンよりもゴーストのバージョンが低いですが、ゴーストのバージョンよりも高いバージョンのお茶会イベントについて、単語を当てはめたりなどトークの内容を変化させて自動的に対応することができます。
-					</dd>
-					<dt>固定対応</dt>
-					<dd>
-						「奏でる日常の音色」が提供するお茶会の内容によって対応は変化しません。返答イベントのReference0はゴーストの制作者が確認しているお茶会バージョンです。この対応情報を返送したゴーストについては、お茶会の内容選択を考慮しません。
-					</dd>
-				</dl>
-			</div>
-		</section>
-		<section class="category ghost">
-			<h1>ゴースト「卓上誘技」</h1>
-			<ul class="caption link">
-				<li>公開元：<a href="https://tatakinov.github.io/">https://tatakinov.github.io/</a></li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="OnPoker">
-				<dt class="entry">OnPoker</dt>
-				<dd class="entry">
-					<p>応答が必要なイベント。応答方法はraiseotherかnotifyotherを使う。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>プロトコルバージョン(POKER/1.0)</dd>
-						<dt>Reference1</dt>
-						<dd>サーバーゴースト名</dd>
-						<dt>Reference2</dt>
-						<dd>サーバーのイベント名</dd>
-					</dl>
-					<section id="reference_OnPoker">
-						<h1>POKER/1.0におけるReference3以降の追加情報</h1>
-						<dl class="reference">
-							<dt>Reference3</dt>
-							<dd>hello（参加申請をする。断られることもある。）</dd>
-						</dl>
-						<dl class="reference">
-							<dt>Reference3</dt>
-							<dd>action（Reference4以降に使用可能なアクションが入っている。）</dd>
-							<dt>Reference*</dt>
-							<dd>使用可能なアクションはbet,raise,allin,check,call,foldの6つの内のいくつか。<br />
-								返答しない場合は自動的にfoldになるので注意。<br />
-								bet/raiseする場合はレイズ額も送る必要がある。</dd>
-						</dl>
-					</section>
-				</dd>
-			</dl>
-			<dl id="OnPokerNotify">
-				<dt class="entry">OnPokerNotify</dt>
-				<dd class="entry">
-					<p>応答する必要の無いイベント。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>プロトコルバージョン(POKER/1.0)</dd>
-					</dl>
-					<section id="reference_OnPokerNotify">
-						<h1>POKER/1.0におけるReference1以降の追加情報</h1>
-						<dl class="reference">
-							<dt>Reference1</dt>
-							<dd>game_start</dd>
-							<dt>Reference*</dt>
-							<dd>参加できたゴースト名</dd>
-						</dl>
-						<dl class="reference">
-							<dt>Reference1</dt>
-							<dd>round_start</dd>
-							<dt>Reference2</dt>
-							<dd>ブラインドの金額</dd>
-							<dt>Reference*</dt>
-							<dd>ゴースト名(バイト値1)スタック</dd>
-						</dl>
-						<dl class="reference">
-							<dt>Reference1</dt>
-							<dd>hand</dd>
-							<dt>Reference2</dt>
-							<dd>配られたカードの情報</dd>
-							<dt>Reference3</dt>
-							<dd>配られたカードの情報<br />
-								スートは頭文字(S,H,C,D)の4つのいずれか、その後に数字が続く。<br />
-								例:<br />
-								Reference2: S1<br />
-								Reference3: H12<br />
-								この形式はFLIPでも一緒。
-							</dd>
-						</dl>
-						<dl class="reference">
-							<dt>Reference1</dt>
-							<dd>flip</dd>
-							<dt>Reference2</dt>
-							<dd>現在のポット</dd>
-							<dt>Reference*</dt>
-							<dd>コミュニティカードの情報<br />
-								プリフロップならReference3以降は存在しない</dd>
-						</dl>
-						<dl class="reference">
-							<dt>Reference1</dt>
-							<dd>blind_bet</dd>
-							<dt>Reference2</dt>
-							<dd>強制ベットの金額<br />
-								SBやBBでの強制ベットをしたことが通知される。</dd>
-						</dl>
-						<dl class="reference">
-							<dt>Reference1</dt>
-							<dd>bet（アクションを行ったプレイヤーとベット周りの情報。）</dd>
-							<dt>Reference2</dt>
-							<dd>現在のベット総額</dd>
-							<dt>Reference3</dt>
-							<dd>現在のベット額</dd>
-							<dt>Reference4</dt>
-							<dd>アクションを行ったプレイヤーのゴースト名</dd>
-							<dt>Reference5</dt>
-							<dd>行ったアクション</dd>
-						</dl>
-						<dl class="reference">
-							<dt>Reference1</dt>
-							<dd>show_down（ショーダウン時のカード情報が送られてくる。）</dd>
-							<dt>Reference*</dt>
-							<dd>ゴースト名(バイト値1)1枚目のカード(バイト値1)2枚目のカード</dd>
-						</dl>
-						<dl class="reference">
-							<dt>Reference1</dt>
-							<dd>round_result（そのラウンドの勝者、および参加者の残りスタックの情報。）</dd>
-							<dt>Reference2</dt>
-							<dd>現在のラウンドの勝者がバイト値1区切りで入っている。</dd>
-							<dt>Reference*</dt>
-							<dd>ゴースト名(バイト値1)スタック<br />
-								基本的に勝者は1人だが2人以上になるケースもある。<br />
-								また、スタックが0になったのはここでしか通知しないため注意。</dd>
-						</dl>
-						<dl class="reference">
-							<dt>Reference1</dt>
-							<dd>game_result</dd>
-							<dt>Reference2</dt>
-							<dd>ゲームの勝者のゴースト名</dd>
-						</dl>
-					</section>
-				</dd>
-			</dl>
-		</section>
-		<section class="category ghost">
-			<h1>ゴースト「フォーリナー」サプリメント「march of phantasma」</h1>
-			<ul class="caption link">
-				<li>公開元：<a href="http://rakudaya.sakura.tv/mop/beta.html">http://rakudaya.sakura.tv/mop/beta.html</a></li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="OnMopClear">
-				<dt class="entry">OnMopClear</dt>
-				<dd class="entry">
-					<p>マップクリア時に通知。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>クリア時のメンバーをバイト値1区切り（固有ユニットのみ）。</dd>
-						<dt>Reference1</dt>
-						<dd>クリアしたマップ名。</dd>
-					</dl>
-				</dd>
-			</dl>
-		</section>
 		<section class="category application">
 			<h1>ゴースト開発用の対話型exe「ゴースト・ターミナル」</h1>
 			<ul class="caption link">
@@ -2987,603 +3432,6 @@
 				</dd>
 			</dl>
 		</section>
-		<section class="category plugin">
-			<h1>プラグイン「Weather Station」</h1>
-			<ul class="caption link">
-				<li>公開元：<a href="https://ukagaka.zichqec.com/plugin/weather_station">https://ukagaka.zichqec.com/plugin/weather_station</a></li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="OnWeatherStation.Weather">
-				<dt class="entry">OnWeatherStation.Weather</dt>
-				<dd class="entry">
-					<p>Sends information about the current weather conditions to all open ghosts. This event occurs every hour, every time another ghost boots, and any time any ghost requests it with \![raiseplugin].</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>Weather condition. <a href="#caption_weather_station_conditions">※See below</a> for a list of possible weather conditions.</dd>
-						<dt>Reference1</dt>
-						<dd>Weather condition icon filename. To be used with weatherapi's <a href="https://cdn.weatherapi.com/weather.zip">weather icon pack</a>.</dd>
-						<dt>Reference2</dt>
-						<dd>Weather condition code. <a href="#caption_weather_station_conditions">※See below</a> for a list of possible weather condition codes.</dd>
-						<dt>Reference3</dt>
-						<dd>If it is daytime or not. 1 if the sun is up, 0 if the sun is down.</dd>
-						<dt>Reference4</dt>
-						<dd>Temperature in Fahrenheit.</dd>
-						<dt>Reference5</dt>
-						<dd>Temperature in Celsius.</dd>
-						<dt>Reference6</dt>
-						<dd>"Feels like" temperature in Fahrenheit.</dd>
-						<dt>Reference7</dt>
-						<dd>"Feels like" temperature in Celsius.</dd>
-						<dt>Reference8</dt>
-						<dd>Humidity as a percentage.</dd>
-						<dt>Reference9</dt>
-						<dd>Wind speed in miles per hour.</dd>
-						<dt>Reference10</dt>
-						<dd>Wind speed in kilometers per hour.</dd>
-						<dt>Reference11</dt>
-						<dd>Wind direction as a 16 point compass. (e.g.: NNE for north/northeast.)</dd>
-						<dt>Reference12</dt>
-						<dd>Wind direction in degrees.</dd>
-						<dt>Reference13</dt>
-						<dd>Wind gust speed in miles per hour.</dd>
-						<dt>Reference14</dt>
-						<dd>Wind gust speed in kilometers per hour.</dd>
-						<dt>Reference15</dt>
-						<dd>Precipitation in inches.</dd>
-						<dt>Reference16</dt>
-						<dd>Precipitation in millimeters.</dd>
-						<dt>Reference17</dt>
-						<dd>Cloud cover as a percentage.</dd>
-						<dt>Reference18</dt>
-						<dd>"Will it rain today". 1 for yes, 0 for no. Same information as the "Will it rain today" in OnWeatherStation.Forecast.Day.</dd>
-						<dt>Reference19</dt>
-						<dd>Chance of rain today, as a percentage. Same information as the chance of rain in OnWeatherStation.Forecast.Day.</dd>
-						<dt>Reference20</dt>
-						<dd>"Will it snow today". 1 for yes, 0 for no. Same information as the "Will it snow today" in OnWeatherStation.Forecast.Day.</dd>
-						<dt>Reference21</dt>
-						<dd>Chance of snow today, as a percentage. Same information as the chance of snow in OnWeatherStation.Forecast.Day.</dd>
-						<dt>Reference22</dt>
-						<dd>Visibility in miles.</dd>
-						<dt>Reference23</dt>
-						<dd>Visibility in kilometers.</dd>
-						<dt>Reference24</dt>
-						<dd>Pressure in inches.</dd>
-						<dt>Reference25</dt>
-						<dd>Pressure in millibars.</dd>
-						<dt>Reference26</dt>
-						<dd>UV index.</dd>
-						<dt>Reference27</dt>
-						<dd>CO (Carbon Monoxide) in μg/m3 (Micrograms per cubic meter).</dd>
-						<dt>Reference28</dt>
-						<dd>O3 (Ozone) in μg/m3 (Micrograms per cubic meter).</dd>
-						<dt>Reference29</dt>
-						<dd>NO2 (Nitrogen Dioxide) in μg/m3 (Micrograms per cubic meter).</dd>
-						<dt>Reference30</dt>
-						<dd>SO2 (Sulfur Dioxide) in μg/m3 (Micrograms per cubic meter).</dd>
-						<dt>Reference31</dt>
-						<dd>PM2.5 (Particulate Matter smaller than 2.5 microns in diameter) in μg/m3 (Micrograms per cubic meter).</dd>
-						<dt>Reference32</dt>
-						<dd>PM10 (Particulate Matter smaller than 10 microns in diameter) in μg/m3 (Micrograms per cubic meter).</dd>
-						<dt>Reference33</dt>
-						<dd>US EPA index. 1 means Good, 2 means Moderate, 3 means Unhealthy for sensitive group, 4 means Unhealthy, 5 means Very unhealthy, 6 means Hazardous.</dd>
-						<dt>Reference34</dt>
-						<dd>UK Defra Index. <a href="#caption_weather_station_uk_defra_index">※See below</a> for details.</dd>
-						<dt>Reference35</dt>
-						<dd>The user's choice of units (Imperial or Metric).</dd>
-						<dt>Reference36</dt>
-						<dd>The time the plugin last updated the weather data, in seconds since EPOCH (1970/1/1 00:00:00).</dd>
-						<dt>Reference37</dt>
-						<dd>The current version number of the plugin.</dd>
-						<dt>Reference38</dt>
-						<dd>The user's location name. Only available if the user has chosen to share their location data.</dd>
-						<dt>Reference39</dt>
-						<dd>The url for the user's location, to be used with the API. Only available if the user has chosen to share their location data.</dd>
-						<dt>Reference40</dt>
-						<dd>The user's latitude. Only available if the user has chosen to share their location data.</dd>
-						<dt>Reference41</dt>
-						<dd>The user's longitude. Only available if the user has chosen to share their location data.</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="OnWeatherStation.Astro">
-				<dt class="entry">OnWeatherStation.Astro</dt>
-				<dd class="entry">
-					<p>Sends information about the sun and moon to all open ghosts. Must be called with \![raiseplugin]. An additional argument can be sent to specify which day's data should be sent. 0 for today, 1 for tomorrow, 2 for the day after tomorrow. If no argument is given, it will default to today.</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>The day the following information is for. 0 for today, 1 for tomorrow, 2 for the day after tomorrow.</dd>
-						<dt>Reference1</dt>
-						<dd>Sunrise time, given as 12 hour time with the format ##:## *M</dd>
-						<dt>Reference2</dt>
-						<dd>Sunset time, given as 12 hour time with the format ##:## *M</dd>
-						<dt>Reference3</dt>
-						<dd>Moonrise time, given as 12 hour time with the format ##:## *M</dd>
-						<dt>Reference4</dt>
-						<dd>Moonset time, given as 12 hour time with the format ##:## *M</dd>
-						<dt>Reference5</dt>
-						<dd>Sunrise time, given as 24 hour time with the format ##:##</dd>
-						<dt>Reference6</dt>
-						<dd>Sunset time, given as 24 hour time with the format ##:##</dd>
-						<dt>Reference7</dt>
-						<dd>Moonrise time, given as 24 hour time with the format ##:##</dd>
-						<dt>Reference8</dt>
-						<dd>Moonset time, given as 24 hour time with the format ##:##</dd>
-						<dt>Reference9</dt>
-						<dd>Moon phase as a string. Can be "New Moon", "Waxing Crescent". "First Quarter", "Waxing Gibbous", "Full Moon", "Waning Gibbous", "Last Quarter", or "Waning Crescent".</dd>
-						<dt>Reference10</dt>
-						<dd>Moon phase number. Numbers correspond to the following phases.
-						<ul>
-							<li>0 - New Moon</li>
-							<li>1 - Waxing Crescent</li>
-							<li>2 - First Quarter</li>
-							<li>3 - Waxing Gibbous</li>
-							<li>4 - Full Moon</li>
-							<li>5 - Waning Gibbous</li>
-							<li>6 - Last Quarter</li>
-							<li>7 - Waning Crescent</li>
-						</ul>
-						</dd>
-						<dt>Reference11</dt>
-						<dd>Moon illumination as a percentage.</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="OnWeatherStation.Alerts">
-				<dt class="entry">OnWeatherStation.Alerts</dt>
-				<dd class="entry">
-					<p>Sends information about weather alerts to all open ghosts. Must be called with \![raiseplugin]. Will return nothing if there are no alerts.</p>
-					<dl class="reference">
-						<dt>Reference*</dt>
-						<dd>An array containing information for a weather alert. Some elements may not be filled. Elements are separated by a 1 byte value.
-						<ul>
-							<!--I have no idea what a lot of these mean! If anyone else knows please feel free to detail it.-->
-							<li>[0] - Headline</li>
-							<li>[1] - Type of alert</li>
-							<li>[2] - Severity</li>
-							<li>[3] - Urgency</li>
-							<li>[4] - Areas covered</li>
-							<li>[5] - Category</li>
-							<li>[6] - Certainty</li>
-							<li>[7] - Event</li>
-							<li>[8] - Note</li>
-							<li>[9] - Effective time</li>
-							<li>[10] - Expires time</li>
-							<li>[11] - Description</li>
-							<li>[12] - Instructions</li>
-						</ul>
-						</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="OnWeatherStation.Forecast.Day">
-				<dt class="entry">OnWeatherStation.Forecast.Day</dt>
-				<dd class="entry">
-					<p>Sends information about the overall forecast for a day to all open ghosts. Must be called with \![raiseplugin]. An additional argument can be sent to specify which day's data should be sent. 0 for today, 1 for tomorrow, 2 for the day after tomorrow. If no argument is given, it will default to today.</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>The day the following information is for. 0 for today, 1 for tomorrow, 2 for the day after tomorrow.</dd>
-						<dt>Reference1</dt>
-						<dd>Maximum temperature for the day, in Fahrenheit.</dd>
-						<dt>Reference2</dt>
-						<dd>Maximum temperature for the day, in Celsius.</dd>
-						<dt>Reference3</dt>
-						<dd>Minimum temperature for the day, in Fahrenheit.</dd>
-						<dt>Reference4</dt>
-						<dd>Minimum temperature for the day, in Celsius.</dd>
-						<dt>Reference5</dt>
-						<dd>Average temperature for the day, in Fahrenheit.</dd>
-						<dt>Reference6</dt>
-						<dd>Average temperature for the day, in Celsius.</dd>
-						<dt>Reference7</dt>
-						<dd>Average humidity for the day, as a percentage.</dd>
-						<dt>Reference8</dt>
-						<dd>Maximum windspeed for the day, in mph.</dd>
-						<dt>Reference9</dt>
-						<dd>Maximum windspeed for the day, in kph.</dd>
-						<dt>Reference10</dt>
-						<dd>Total precipitation for the day, in inches.</dd>
-						<dt>Reference11</dt>
-						<dd>Total precipitation for the day, in millimeters.</dd>
-						<dt>Reference12</dt>
-						<dd>"Will it rain this day", 1 if yes, 0 if no.</dd>
-						<dt>Reference13</dt>
-						<dd>Chance that it will rain this day, as a percentage.</dd>
-						<dt>Reference14</dt>
-						<dd>"Will it snow this day", 1 if yes, 0 if no.</dd>
-						<dt>Reference15</dt>
-						<dd>Chance that it will snow this day, as a percentage.</dd>
-						<dt>Reference16</dt>
-						<dd>Average visiblity for the day, in miles.</dd>
-						<dt>Reference17</dt>
-						<dd>Average visiblity for the day, in kilometers.</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="OnWeatherStation.Forecast.Hourly">
-				<dt class="entry">OnWeatherStation.Forecast.Hourly</dt>
-				<dd class="entry">
-					<p>Sends information about the hour-by-hour forecast for a day to all open ghosts. Must be called with \![raiseplugin]. An additional argument can be sent to specify which day's data should be sent. 0 for today, 1 for tomorrow, 2 for the day after tomorrow. If no argument is given, it will default to today.</p>
-					<dl class="reference">
-						<dt>Reference0～23</dt>
-						<dd>A comma separated array containing forecast information. The number of the reference corresponds to the number of the hour the data is for, in 24 hour time (e.g.: reference0 is for 00:00/12AM, reference14 is for 14:00/2PM).
-						<ul>
-							<li>[0] - Date and time the information is for.</li>
-							<li>[1] - "Is it daytime". 1 if the sun is up, 0 if the sun is down.</li>
-							<li>[2] - Temperature in Fahrenheit.</li>
-							<li>[3] - Temperature in Celsius.</li>
-							<li>[4] - "Feels like" temperature in Fahrenheit.</li>
-							<li>[5] - "Feels like" temperature in Celsius.</li>
-							<li>[6] - Humidity as a percentage.</li>
-							<li>[7] - Wind speed in miles per hour.</li>
-							<li>[8] - Wind speed in kilometers per hour.</li>
-							<li>[9] - Wind direction as a 16 point compass (e.g.: NNW for north/northwest).</li>
-							<li>[10] - Wind direction in degrees.</li>
-							<li>[11] - Wind gusts in miles per hour.</li>
-							<li>[12] - Wind gusts in kilometers per hour.</li>
-							<li>[13] - Precipitation in inches.</li>
-							<li>[14] - Precipitation in millimeters.</li>
-							<li>[15] - Cloud cover as a percentage.</li>
-							<li>[16] - "Will it rain", 1 if yes, 0 if no.</li>
-							<li>[17] - Chance of rain as a percentage.</li>
-							<li>[18] - "Will it snow", 1 if yes, 0 if no.</li>
-							<li>[19] - Chance of snow as a percentage.</li>
-							<li>[20] - Visibility in miles.</li>
-							<li>[21] - Visibility in kilometers.</li>
-							<li>[22] - Wind chill in Fahrenheit.</li>
-							<li>[23] - Wind chill in Celsius.</li>
-							<li>[24] - Heat index in Fahrenheit.</li>
-							<li>[25] - Heat index in Celsius.</li>
-							<li>[26] - Dew point in Fahrenheit.</li>
-							<li>[27] - Dew point in Celsius.</li>
-							<li>[28] - Pressure in inches.</li>
-							<li>[29] - Pressure in millibars.</li>
-							<li>[30] - UV index.</li>
-						</ul>
-						</dd>
-						<dt>Reference24</dt>
-						<dd>The day the preceding information is for. 0 for today, 1 for tomorrow, 2 for the day after tomorrow.</dd>
-					</dl>
-				</dd>
-			</dl>
-			<dl id="OnWeatherStation.Error">
-				<dt class="entry">OnWeatherStation.Error</dt>
-				<dd class="entry">
-					<p>Sends error information to all open ghosts. This event is sent in place of the previous events if there is an error of any kind.</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>The error message. <a href="#caption_weather_station_errors">※See below</a> for possible error messages.</dd>
-						<dt>Reference1</dt>
-						<dd>A more descriptive error message, provided by weatherapi.com. <em>These error messages do not match the online documentation for weatherapi and should not be used for identifying errors.</em></dd>
-						<dt>Reference2</dt>
-						<dd>The error code, as listed on weatherapi.com's documentation.</dd>
-						<dt>Reference3</dt>
-						<dd>The time the plugin last attempted to update the weather data, in seconds since EPOCH (1970/1/1 00:00:00).</dd>
-						<dt>Reference4</dt>
-						<dd>The current version number of the plugin.</dd>
-						<dt>Reference5</dt>
-						<dd>1 if there is a plugin update available, 0 otherwise.</dd>
-					</dl>
-				</dd>
-			</dl>
-			<div class="caption" id="caption_weather_station_conditions">
-				<h1>Weather Condition & Code List</h1>
-				<p>A list of conditions can be downloaded from <a href="https://www.weatherapi.com/docs/">weatherapi's documentation page</a>. This list is also available in other languages, but information from the plugin will always be sent in english.</p>
-				<dl>
-					<dt>1000</dt>
-					<dd>
-						Sunny (If the sun is down, it will be "Clear" instead.)
-					</dd>
-					<dt>1003</dt>
-					<dd>
-						Partly cloudy
-					</dd>
-					<dt>1006</dt>
-					<dd>
-						Cloudy
-					</dd>
-					<dt>1009</dt>
-					<dd>
-						Overcast
-					</dd>
-					<dt>1030</dt>
-					<dd>
-						Mist
-					</dd>
-					<dt>1063</dt>
-					<dd>
-						Patchy rain possible
-					</dd>
-					<dt>1066</dt>
-					<dd>
-						Patchy snow possible
-					</dd>
-					<dt>1069</dt>
-					<dd>
-						Patchy sleet possible
-					</dd>
-					<dt>1072</dt>
-					<dd>
-						Patchy freezing drizzle possible
-					</dd>
-					<dt>1087</dt>
-					<dd>
-						Thundery outbreaks possible
-					</dd>
-					<dt>1114</dt>
-					<dd>
-						Blowing snow
-					</dd>
-					<dt>1117</dt>
-					<dd>
-						Blizzard
-					</dd>
-					<dt>1135</dt>
-					<dd>
-						Fog
-					</dd>
-					<dt>1147</dt>
-					<dd>
-						Freezing fog
-					</dd>
-					<dt>1150</dt>
-					<dd>
-						Patchy light drizzle
-					</dd>
-					<dt>1153</dt>
-					<dd>
-						Light drizzle
-					</dd>
-					<dt>1168</dt>
-					<dd>
-						Freezing drizzle
-					</dd>
-					<dt>1171</dt>
-					<dd>
-						Heavy freezing drizzle
-					</dd>
-					<dt>1180</dt>
-					<dd>
-						Patchy light rain
-					</dd>
-					<dt>1183</dt>
-					<dd>
-						Light rain
-					</dd>
-					<dt>1186</dt>
-					<dd>
-						Moderate rain at times
-					</dd>
-					<dt>1189</dt>
-					<dd>
-						Moderate rain
-					</dd>
-					<dt>1192</dt>
-					<dd>
-						Heavy rain at times
-					</dd>
-					<dt>1195</dt>
-					<dd>
-						Heavy rain
-					</dd>
-					<dt>1198</dt>
-					<dd>
-						Light freezing rain
-					</dd>
-					<dt>1201</dt>
-					<dd>
-						Moderate or heavy freezing rain
-					</dd>
-					<dt>1204</dt>
-					<dd>
-						Light sleet
-					</dd>
-					<dt>1207</dt>
-					<dd>
-						Moderate or heavy sleet
-					</dd>
-					<dt>1210</dt>
-					<dd>
-						Patchy light snow
-					</dd>
-					<dt>1213</dt>
-					<dd>
-						Light snow
-					</dd>
-					<dt>1216</dt>
-					<dd>
-						Patchy moderate snow
-					</dd>
-					<dt>1219</dt>
-					<dd>
-						Moderate snow
-					</dd>
-					<dt>1222</dt>
-					<dd>
-						Patchy heavy snow
-					</dd>
-					<dt>1225</dt>
-					<dd>
-						Heavy snow
-					</dd>
-					<dt>1237</dt>
-					<dd>
-						Ice pellets
-					</dd>
-					<dt>1240</dt>
-					<dd>
-						Light rain shower
-					</dd>
-					<dt>1243</dt>
-					<dd>
-						Moderate or heavy rain shower
-					</dd>
-					<dt>1246</dt>
-					<dd>
-						Torrential rain shower
-					</dd>
-					<dt>1249</dt>
-					<dd>
-						Light sleet showers
-					</dd>
-					<dt>1252</dt>
-					<dd>
-						Moderate or heavy sleet showers
-					</dd>
-					<dt>1255</dt>
-					<dd>
-						Light snow showers
-					</dd>
-					<dt>1258</dt>
-					<dd>
-						Moderate or heavy snow showers
-					</dd>
-					<dt>1261</dt>
-					<dd>
-						Light showers of ice pellets
-					</dd>
-					<dt>1264</dt>
-					<dd>
-						Moderate or heavy showers of ice pellets
-					</dd>
-					<dt>1273</dt>
-					<dd>
-						Patchy light rain with thunder
-					</dd>
-					<dt>1276</dt>
-					<dd>
-						Moderate or heavy rain with thunder
-					</dd>
-					<dt>1279</dt>
-					<dd>
-						Patchy light snow with thunder
-					</dd>
-					<dt>1282</dt>
-					<dd>
-						Moderate or heavy snow with thunder
-					</dd>
-				</dl>
-			</div>
-			<div class="caption" id="caption_weather_station_uk_defra_index">
-				<h1>UK Defra Index reference</h1>
-				<table>
-					<tr>
-						<th>Index</th>
-						<td>1</td>
-						<td>2</td>
-						<td>3</td>
-						<td>4</td>
-						<td>5</td>
-						<td>6</td>
-						<td>7</td>
-						<td>8</td>
-						<td>9</td>
-						<td>10</td>
-					</tr>
-					<tr>
-						<th>Band</th>
-						<td>Low</td>
-						<td>Low</td>
-						<td>Low</td>
-						<td>Moderate</td>
-						<td>Moderate</td>
-						<td>Moderate</td>
-						<td>High</td>
-						<td>High</td>
-						<td>High</td>
-						<td>Very High</td>
-					</tr>
-					<tr>
-						<th>µgm-3</th>
-						<td>0-11</td>
-						<td>12-23</td>
-						<td>24-35</td>
-						<td>36-41</td>
-						<td>42-47</td>
-						<td>48-53</td>
-						<td>54-58</td>
-						<td>59-64</td>
-						<td>65-70</td>
-						<td>71 or more</td>
-					</tr>
-				</table>
-			</div>
-			<div class="caption" id="caption_weather_station_errors">
-				<h1>Reason for Error</h1>
-				<dl>
-					<dt>no_location</dt>
-					<dd>
-						The user has not added their location, or has removed it.
-					</dd>
-					<dt>location_invalid</dt>
-					<dd>
-						The user's location is invalid and data cannot be gathered.
-					</dd>
-					<dt>api_quota_exceeded</dt>
-					<dd>
-						The 1 million free API calls per month has been exceeded.
-					</dd>
-					<dt>api_key_disabled</dt>
-					<dd>
-						The API key has been disabled by the plugin developer. Please check if a plugin update is available to provide a new key.
-					</dd>
-					<dt>api_internal_error</dt>
-					<dd>
-						The API responded with an internal error.
-					</dd>
-					<dt>no_api_response</dt>
-					<dd>
-						The API did not respond, or the SAORI used by the plugin failed to work.
-					</dd>
-					<dt>other</dt>
-					<dd>
-						Any other error sent by the API. reference1 will have the error message provided by the API.
-					</dd>
-				</dl>
-			</div>
-		</section>
-		<section class="category ghost">
-			<h1>ゴースト「Needle」</h1>
-			<ul class="caption link">
-				<li>公開元：<a href="https://ukagaka.zichqec.com/ghost/needle">https://ukagaka.zichqec.com/ghost/needle</a></li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="OnNeedlePoke">
-				<dt class="entry">OnNeedlePoke</dt>
-				<dd class="entry">
-					<p>Occurs when Needle "pokes" another ghost (by overlapping them). If Needle is overlapping multiple scopes simultaneously, the event will be sent once for each scope.</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>The ID of the scope that was poked. 0 for the main character, 1 for the side character, 2 and onwards for additional characters.</dd>
-						<dt>Reference1</dt>
-						<dd>The name of the shell Needle is currently using.</dd>
-					</dl>
-				</dd>
-			</dl>
-		</section>
-		<section class="category other">
-			<h1>UKADOC</h1>
-			<ul class="caption link">
-				<li>公開元：<a href="./list_sakura_script.html">さくらスクリプトリスト</a></li>
-			</ul>
-			<ul class="supported-baseware">
-				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
-			</ul>
-			<dl id="OnUkadocScriptExample">
-				<dt class="entry">OnUkadocScriptExample</dt>
-				<dd class="entry">
-					<p>UkadocのSakuraScript Listにあるサンプルスクリプトを実行した際に発生。<br />
-					このイベントを実装する場合は、危険なSakuraScriptタグを自分でエスケープする必要があることに注意。</p>
-					<dl class="reference">
-						<dt>Reference0</dt>
-						<dd>実行するスクリプト。</dd>
-					</dl>
-				</dd>
-			</dl>
-		</section>
 		<section class="category application">
 			<h1>アプリ「Elin」</h1>
 			<ul class="caption link">
@@ -3729,6 +3577,158 @@
                 <p>1キャラクターはキャラクターの名前と持っているアイテムがバイト値1で区切られており、さらにキャラクター毎にバイト値2で区切られている。例：イーク0x02銅の短剣0x01ゴブリン0x02紙の大剣0x02珊瑚の軽外套0x01侍…</p>
 			</div>
         </section>
+		<section class="category other">
+			<h1>外部アプリ汎用イベント</h1>
+			<dl id="OnApplicationBoot">
+				<dt class="entry">OnApplicationBoot</dt>
+				<dd class="entry">
+					<p>外部アプリケーションが起動した際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>アプリケーション名。</dd>
+						<dt>Reference1</dt>
+						<dd>アプリケーションの情報。</dd>
+					</dl>
+					<ul class="supported-baseware">
+						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
+						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
+					</ul>
+				</dd>
+			</dl>
+			<dl id="OnApplicationClose">
+				<dt class="entry">OnApplicationClose</dt>
+				<dd class="entry">
+					<p>外部アプリケーションが終了した際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>アプリケーション名。</dd>
+						<dt>Reference1</dt>
+						<dd>アプリケーションの情報。</dd>
+					</dl>
+					<ul class="supported-baseware">
+						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
+						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
+					</ul>
+				</dd>
+			</dl>
+			<dl id="OnApplicationExist">
+				<dt class="entry">OnApplicationExist</dt>
+				<dd class="entry">
+					<p>外部アプリケーションの存在を通知された際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>アプリケーション名。</dd>
+						<dt>Reference1</dt>
+						<dd>アプリケーションの情報。</dd>
+					</dl>
+					<ul class="supported-baseware">
+						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
+						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
+					</ul>
+				</dd>
+			</dl>
+			<dl id="OnApplicationVersion">
+				<dt class="entry">OnApplicationVersion</dt>
+				<dd class="entry">
+					<p>外部アプリケーションのバージョン情報を通知された際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>アプリケーション名。</dd>
+						<dt>Reference1</dt>
+						<dd>アプリケーションの情報。</dd>
+						<dt>Reference2</dt>
+						<dd>バージョン番号。</dd>
+						<dt>Reference3</dt>
+						<dd>著作権。</dd>
+						<dt>Reference4</dt>
+						<dd>開発元のURL。</dd>
+					</dl>
+					<ul class="supported-baseware">
+						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
+						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
+					</ul>
+				</dd>
+			</dl>
+			<dl id="OnApplicationOperationFinish">
+				<dt class="entry">OnApplicationOperationFinish</dt>
+				<dd class="entry">
+					<p>外部アプリケーションか何らかの処理が完了した際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>アプリケーション名。</dd>
+						<dt>Reference1</dt>
+						<dd>処理の内容。</dd>
+						<dt>Reference2</dt>
+						<dd>処理の対象。</dd>
+					</dl>
+					<ul class="supported-baseware">
+						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
+						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
+					</ul>
+				</dd>
+			</dl>
+			<dl id="OnApplicationFileOpen">
+				<dt class="entry">OnApplicationFileOpen</dt>
+				<dd class="entry">
+					<p>外部アプリケーションがドキュメントファイルを開いた際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>アプリケーション名。</dd>
+						<dt>Reference1</dt>
+						<dd>ファイルのフルパス。</dd>
+					</dl>
+					<ul class="supported-baseware">
+						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
+						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
+					</ul>
+				</dd>
+			</dl>
+			<dl id="OnWebsiteUpdateNotify">
+				<dt class="entry">OnWebsiteUpdateNotify</dt>
+				<dd class="entry">
+					<p>ウェブサイトの更新・新着情報を通知された際に発生。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>ウェブサイト名。</dd>
+						<dt>Reference1</dt>
+						<dd>最終更新日時。</dd>
+						<dt>Reference2</dt>
+						<dd>更新内容。</dd>
+					</dl>
+					<ul class="supported-baseware">
+						<li><img src="image/icon_m.png" alt="Materia" width="34" height="16" /></li>
+						<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+						<li><img src="image/icon_c.png" alt="CROW" width="34" height="16" /></li>
+					</ul>
+				</dd>
+			</dl>
+		</section>
+		<section class="category other">
+			<h1>UKADOC</h1>
+			<ul class="caption link">
+				<li>公開元：<a href="./list_sakura_script.html">さくらスクリプトリスト</a></li>
+			</ul>
+			<ul class="supported-baseware">
+				<li><img src="image/icon_s.png" alt="SSP" width="34" height="16" /></li>
+			</ul>
+			<dl id="OnUkadocScriptExample">
+				<dt class="entry">OnUkadocScriptExample</dt>
+				<dd class="entry">
+					<p>UkadocのSakuraScript Listにあるサンプルスクリプトを実行した際に発生。<br />
+					このイベントを実装する場合は、危険なSakuraScriptタグを自分でエスケープする必要があることに注意。</p>
+					<dl class="reference">
+						<dt>Reference0</dt>
+						<dd>実行するスクリプト。</dd>
+					</dl>
+				</dd>
+			</dl>
+		</section>
 	</div>
 </body>
 </html>

--- a/manual/list_shiori_event_ex.html
+++ b/manual/list_shiori_event_ex.html
@@ -154,39 +154,39 @@
 				<a href="https://github.com/YAYA-shiori/yaya-dic/blob/acef2e384cd5a03eda8873cf82ca10bd720c8138/yaya_base/shiori3.dic#L1990L2025">Get_Supported_Events</a>イベントをサポートして、速度を向上させることができます。
 			</div>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category ghost">
 			<h1>ゴースト間汎用イベント</h1>
 			<ul>
 				<li><a href="#OnRequestValues">OnRequestValues</a></li>
 				<li><a href="#OnGetValues">OnGetValues</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category ghost">
 			<h1>ゴースト「ぬるぽ いんたーはい」</h1>
 			<ul>
 				<li><a href="#OnTalkRequest">OnTalkRequest</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category ghost">
 			<h1>ゴースト「The Hand」</h1>
 			<ul>
 				<li><a href="#OnHandActivate">OnHandActivate</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category ghost">
 			<h1>ゴースト「ごーすとじてん」「きゅーぴっど」</h1>
 			<ul>
 				<li><a href="#OnJitenBattle">OnJitenBattle</a></li>
 				<li><a href="#OnJitenTagBattle">OnJitenTagBattle</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category ghost">
 			<h1>ゴースト「マギルトリエ」</h1>
 			<ul>
 				<li><a href="#OnMglBattle">OnMglBattle</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category ghost">
 			<h1>ゴースト「カレー家族／沙紀と右近」</h1>
 			<ul>
 				<li><a href="#Send60stair_Call">Send60stair_Call</a></li>
@@ -201,7 +201,7 @@
 				<li><a href="#Send60stair_GetStatus">Send60stair_GetStatus</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category ghost">
 			<h1>ゴースト「奏でる日常の音色」</h1>
 			<ul>
 				<li><a href="#OnKanadeTeaPartyInfomationRequest">OnKanadeTeaPartyInfomationRequest</a></li>
@@ -210,44 +210,44 @@
 				<li><a href="#OnKanadeTeaPartyEnd">OnKanadeTeaPartyEnd</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category ghost">
 			<h1>ゴースト「卓上誘技」</h1>
 			<ul>
 				<li><a href="#OnPoker">OnPoker</a></li>
 				<li><a href="#OnPokerNotify">OnPokerNotify</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category ghost">
 			<h1>ゴースト「フォーリナー」サプリメント「march of phantasma」</h1>
 			<ul>
 				<li><a href="#OnMopClear">OnMopClear</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category ghost">
 			<h1>ゴースト「Needle」</h1>
 			<ul>
 				<li><a href="#OnNeedlePoke">OnNeedlePoke</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category plugin">
 			<h1>プラグイン「バーチャルビールかけ（BeerShower）」</h1>
 			<ul>
 				<li><a href="#OnBeerShower">OnBeerShower</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category plugin">
 			<h1>プラグイン「バーチャル道頓堀（TOMBORI）」</h1>
 			<ul>
 				<li><a href="#OnDive">OnDive</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category plugin">
 			<h1>プラグイン「実体化（HitThunder）」</h1>
 			<ul>
 				<li><a href="#OnHitThunder">OnHitThunder</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category plugin">
 			<h1>プラグイン「スタンプ帳」</h1>
 			<ul>
 				<li><a href="#OnStampInfo">OnStampInfo</a></li>
@@ -255,7 +255,7 @@
 				<li><a href="#OnStampInfoCall">OnStampInfoCall</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category plugin">
 			<h1>プラグイン「芋スコープ」</h1>
 			<ul>
 				<li><a href="#OnPotatoReturn">OnPotatoReturn</a></li>
@@ -263,14 +263,14 @@
 				<li><a href="#OnPotatoError">OnPotatoError</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category plugin">
 			<h1>プラグイン「CrystalDiskInfo Event PLUGIN」</h1>
 			<ul>
 				<li><a href="#OnCrystalDiskInfoEvent">OnCrystalDiskInfoEvent</a></li>
 				<li><a href="#OnCrystalDiskInfoClear">OnCrystalDiskInfoClear</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category plugin">
 			<h1>プラグイン「Weather Station」</h1>
 			<ul>
 				<li><a href="#OnWeatherStation.Weather">OnWeatherStation.Weather</a></li>
@@ -281,13 +281,13 @@
 				<li><a href="#OnWeatherStation.Error">OnWeatherStation.Error</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category saori">
 			<h1>SAORI「httpc.dll」</h1>
 			<ul>
 				<li><a href="#OnHttpcNotify">OnHttpcNotify</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>アプリ「きのこ」</h1>
 			<ul>
 				<li><a href="#OnKinokoObjectCreate">OnKinokoObjectCreate</a></li>
@@ -301,7 +301,7 @@
 				<li><a href="#OnSysResourceCritical">OnSysResourceCritical</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>アプリ「猫どりふ」</h1>
 			<ul>
 				<li><a href="#OnNekodorifObjectEmerge">OnNekodorifObjectEmerge</a></li>
@@ -311,19 +311,19 @@
 				<li><a href="#OnNekodorifObjectDodge">OnNekodorifObjectDodge</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>アプリ「YunaSoft SexyFont Plug-in」</h1>
 			<ul>
 				<li><a href="#OnMusicPlay">OnMusicPlay</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>アプリ「艦隊時計」</h1>
 			<ul>
 				<li><a href="#OnFleetClockComplete">OnFleetClockComplete</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>アプリ「Elona omake_MMA」</h1>
 			<ul>
 				<li><a href="#OnElonaOmakeMMAEventNewGame">OnElonaOmakeMMAEventNewGame</a></li>
@@ -389,20 +389,20 @@
 				<li><a href="#OnElonaOmakeMMAEventGrandmapocalypse">OnElonaOmakeMMAEventGrandmapocalypse</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>麻雀通信イベント</h1>
 			<ul>
 				<li><a href="#OnMahjong">OnMahjong</a></li>
 				<li><a href="#OnMahjongResponse">OnMahjongResponse</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>Nostr通知イベント</h1>
 			<ul>
 				<li><a href="#OnNostr">OnNostr</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>アプリ「さとりすと」</h1>
 			<ul>
 				<li><a href="#OnSatolistBoot">OnSatolistBoot</a></li>
@@ -413,7 +413,7 @@
 				<li><a href="#OnSatolistDictionaryFolderChanged">OnSatolistDictionaryFolderChanged</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>GoogleChrome拡張「とうらぶえくすてんしょん」</h1>
 			<ul>
 				<li><a href="#OnTourabuConquestStart">OnTourabuConquestStart</a></li>
@@ -422,7 +422,7 @@
 				<li><a href="#OnTourabuDutyEnd">OnTourabuDutyEnd</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>ゴースト開発用の対話型exe「ゴースト・ターミナル」</h1>
 			<ul>
 				<li><a href="#ShioriEcho.Begin">ShioriEcho.Begin</a></li>
@@ -440,7 +440,7 @@
 				<li><a href="#ShioriEcho.CommandHistory.ForwardIndex">ShioriEcho.CommandHistory.ForwardIndex</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category application">
 			<h1>アプリ「Elin」</h1>
 			<ul>
 				<li><a href="#OnElinAllyCondition">OnElinAllyCondition</a></li>
@@ -454,7 +454,7 @@
 				<li><a href="#OnElinTarget">OnElinTarget</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category other">
 			<h1>外部アプリ汎用イベント</h1>
 			<ul>
 				<li><a href="#OnApplicationBoot">OnApplicationBoot</a></li>
@@ -466,7 +466,7 @@
 				<li><a href="#OnWebsiteUpdateNotify">OnWebsiteUpdateNotify</a></li>
 			</ul>
 		</section>
-		<section class="navigation-category">
+		<section class="navigation-category other">
 			<h1>UKADOC</h1>
 			<ul>
 				<li><a href="#OnUkadocScriptExample">OnUkadocScriptExample</a></li>


### PR DESCRIPTION
Rearrange items on the external SHIORI events list to be by category.

I've arranged them in the order Ghost > Plugin > SAORI > Application > Other

The idea being that the top of the list comes from ukagaka-related sources, and the further down you go the less ukagaka-related the event sources are.

I have not alphabetized the list, this order assumes that items will be added to the bottom of each list as new things are made.